### PR TITLE
Add domain metrics module for MAE, RMSE, and accuracy calculations

### DIFF
--- a/src/finsight/cli/main.py
+++ b/src/finsight/cli/main.py
@@ -5,6 +5,7 @@ import argparse
 from finsight.application.use_cases.train_model import TrainModelRequest
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -51,9 +52,9 @@ def _run_train(args: argparse.Namespace) -> int:
         print(f"[{model_type}] run_dir={run_dir}")
         print(
             "  "
-            f"MAE={float(model_metrics['mae']):.6f} "
-            f"RMSE={float(model_metrics['rmse']):.6f} "
-            f"DirectionAcc={float(model_metrics['direction_accuracy']):.4f}"
+            f"MAE={float(model_metrics[METRIC_MAE]):.6f} "
+            f"RMSE={float(model_metrics[METRIC_RMSE]):.6f} "
+            f"DirectionAcc={float(model_metrics[METRIC_DIRECTION_ACCURACY]):.4f}"
         )
 
     return 0

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+METRIC_MAE = "mae"
+METRIC_RMSE = "rmse"
+METRIC_DIRECTION_ACCURACY = "direction_accuracy"
+
+SUPPORTED_METRIC_NAMES = (
+	METRIC_MAE,
+	METRIC_RMSE,
+	METRIC_DIRECTION_ACCURACY,
+)
+
+
+def mean_absolute_error(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
+	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+	return float(sum(abs(a - b) for a, b in zip(true_values, pred_values)) / len(true_values))
+
+
+def root_mean_squared_error(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
+	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+	mse = sum((a - b) ** 2 for a, b in zip(true_values, pred_values)) / len(true_values)
+	return float(math.sqrt(mse))
+
+
+def direction_accuracy(
+	y_true: Sequence[float],
+	y_pred: Sequence[float],
+	*,
+	positive_threshold: float = 0.0,
+) -> float:
+	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+	matching_directions = sum(
+		int((a > positive_threshold) == (b > positive_threshold))
+		for a, b in zip(true_values, pred_values)
+	)
+	return float(matching_directions / len(true_values))
+
+
+def forecast_metrics(y_true: Sequence[float], y_pred: Sequence[float]) -> dict[str, float]:
+	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+	return {
+		METRIC_MAE: mean_absolute_error(true_values, pred_values),
+		METRIC_RMSE: root_mean_squared_error(true_values, pred_values),
+		METRIC_DIRECTION_ACCURACY: direction_accuracy(true_values, pred_values),
+	}
+
+
+def _coerce_and_validate_inputs(
+	y_true: Sequence[float],
+	y_pred: Sequence[float],
+) -> tuple[list[float], list[float]]:
+	true_values = [float(value) for value in y_true]
+	pred_values = [float(value) for value in y_pred]
+
+	if not true_values or not pred_values:
+		raise ValueError("y_true and y_pred must be non-empty.")
+
+	if len(true_values) != len(pred_values):
+		raise ValueError("y_true and y_pred must have the same length.")
+
+	return true_values, pred_values

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -15,13 +15,13 @@ SUPPORTED_METRIC_NAMES = (
 
 
 def mean_absolute_error(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
-    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-    return float(sum(abs(a - b) for a, b in zip(true_values, pred_values)) / len(true_values))
+    count = _validate_input_lengths(y_true, y_pred)
+    return float(sum(abs(float(a) - float(b)) for a, b in zip(y_true, y_pred)) / count)
 
 
 def root_mean_squared_error(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
-    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-    mse = sum((a - b) ** 2 for a, b in zip(true_values, pred_values)) / len(true_values)
+    count = _validate_input_lengths(y_true, y_pred)
+    mse = sum((float(a) - float(b)) ** 2 for a, b in zip(y_true, y_pred)) / count
     return float(math.sqrt(mse))
 
 
@@ -31,12 +31,12 @@ def direction_accuracy(
     *,
     positive_threshold: float = 0.0,
 ) -> float:
-    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+    count = _validate_input_lengths(y_true, y_pred)
     matching_directions = sum(
-        int((a > positive_threshold) == (b > positive_threshold))
-        for a, b in zip(true_values, pred_values)
+        int((float(a) > positive_threshold) == (float(b) > positive_threshold))
+        for a, b in zip(y_true, y_pred)
     )
-    return float(matching_directions / len(true_values))
+    return float(matching_directions / count)
 
 
 def forecast_metrics(
@@ -45,19 +45,19 @@ def forecast_metrics(
     *,
     positive_threshold: float = 0.0,
 ) -> dict[str, float]:
-    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-
-    count = len(true_values)
+    count = _validate_input_lengths(y_true, y_pred)
     abs_error_sum = 0.0
     squared_error_sum = 0.0
     matching_directions = 0
 
-    for true_val, pred_val in zip(true_values, pred_values):
+    for true_raw, pred_raw in zip(y_true, y_pred):
+        true_val = float(true_raw)
+        pred_val = float(pred_raw)
         error = true_val - pred_val
         abs_error_sum += abs(error)
         squared_error_sum += error ** 2
         matching_directions += int((true_val > positive_threshold) == (pred_val > positive_threshold))
-    
+
     return {
         METRIC_MAE: float(abs_error_sum / count),
         METRIC_RMSE: float(math.sqrt(squared_error_sum / count)),
@@ -65,17 +65,17 @@ def forecast_metrics(
     }
 
 
-def _coerce_and_validate_inputs(
+def _validate_input_lengths(
     y_true: Sequence[float],
     y_pred: Sequence[float],
-) -> tuple[list[float], list[float]]:
-    true_values = [float(value) for value in y_true]
-    pred_values = [float(value) for value in y_pred]
+) -> int:
+    true_len = len(y_true)
+    pred_len = len(y_pred)
 
-    if not true_values or not pred_values:
+    if true_len == 0 or pred_len == 0:
         raise ValueError("y_true and y_pred must be non-empty.")
 
-    if len(true_values) != len(pred_values):
+    if true_len != pred_len:
         raise ValueError("y_true and y_pred must have the same length.")
 
-    return true_values, pred_values
+    return true_len

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -8,57 +8,57 @@ METRIC_RMSE = "rmse"
 METRIC_DIRECTION_ACCURACY = "direction_accuracy"
 
 SUPPORTED_METRIC_NAMES = (
-	METRIC_MAE,
-	METRIC_RMSE,
-	METRIC_DIRECTION_ACCURACY,
+    METRIC_MAE,
+    METRIC_RMSE,
+    METRIC_DIRECTION_ACCURACY,
 )
 
 
 def mean_absolute_error(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
-	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-	return float(sum(abs(a - b) for a, b in zip(true_values, pred_values)) / len(true_values))
+    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+    return float(sum(abs(a - b) for a, b in zip(true_values, pred_values)) / len(true_values))
 
 
 def root_mean_squared_error(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
-	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-	mse = sum((a - b) ** 2 for a, b in zip(true_values, pred_values)) / len(true_values)
-	return float(math.sqrt(mse))
+    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+    mse = sum((a - b) ** 2 for a, b in zip(true_values, pred_values)) / len(true_values)
+    return float(math.sqrt(mse))
 
 
 def direction_accuracy(
-	y_true: Sequence[float],
-	y_pred: Sequence[float],
-	*,
-	positive_threshold: float = 0.0,
+    y_true: Sequence[float],
+    y_pred: Sequence[float],
+    *,
+    positive_threshold: float = 0.0,
 ) -> float:
-	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-	matching_directions = sum(
-		int((a > positive_threshold) == (b > positive_threshold))
-		for a, b in zip(true_values, pred_values)
-	)
-	return float(matching_directions / len(true_values))
+    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+    matching_directions = sum(
+        int((a > positive_threshold) == (b > positive_threshold))
+        for a, b in zip(true_values, pred_values)
+    )
+    return float(matching_directions / len(true_values))
 
 
 def forecast_metrics(y_true: Sequence[float], y_pred: Sequence[float]) -> dict[str, float]:
-	true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
-	return {
-		METRIC_MAE: mean_absolute_error(true_values, pred_values),
-		METRIC_RMSE: root_mean_squared_error(true_values, pred_values),
-		METRIC_DIRECTION_ACCURACY: direction_accuracy(true_values, pred_values),
-	}
+    true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+    return {
+        METRIC_MAE: mean_absolute_error(true_values, pred_values),
+        METRIC_RMSE: root_mean_squared_error(true_values, pred_values),
+        METRIC_DIRECTION_ACCURACY: direction_accuracy(true_values, pred_values),
+    }
 
 
 def _coerce_and_validate_inputs(
-	y_true: Sequence[float],
-	y_pred: Sequence[float],
+    y_true: Sequence[float],
+    y_pred: Sequence[float],
 ) -> tuple[list[float], list[float]]:
-	true_values = [float(value) for value in y_true]
-	pred_values = [float(value) for value in y_pred]
+    true_values = [float(value) for value in y_true]
+    pred_values = [float(value) for value in y_pred]
 
-	if not true_values or not pred_values:
-		raise ValueError("y_true and y_pred must be non-empty.")
+    if not true_values or not pred_values:
+        raise ValueError("y_true and y_pred must be non-empty.")
 
-	if len(true_values) != len(pred_values):
-		raise ValueError("y_true and y_pred must have the same length.")
+    if len(true_values) != len(pred_values):
+        raise ValueError("y_true and y_pred must have the same length.")
 
-	return true_values, pred_values
+    return true_values, pred_values

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -46,13 +46,12 @@ def forecast_metrics(y_true: Sequence[float], y_pred: Sequence[float]) -> dict[s
     abs_error_sum = 0.0
     squared_error_sum = 0.0
     matching_directions = 0
-    
+
     for true_val, pred_val in zip(true_values, pred_values):
         error = true_val - pred_val
         abs_error_sum += abs(error)
         squared_error_sum += error ** 2
         matching_directions += int((true_val > 0.0) == (pred_val > 0.0))
-    
     return {
         METRIC_MAE: float(abs_error_sum / count),
         METRIC_RMSE: float(math.sqrt(squared_error_sum / count)),

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -39,7 +39,12 @@ def direction_accuracy(
     return float(matching_directions / len(true_values))
 
 
-def forecast_metrics(y_true: Sequence[float], y_pred: Sequence[float]) -> dict[str, float]:
+def forecast_metrics(
+    y_true: Sequence[float],
+    y_pred: Sequence[float],
+    *,
+    positive_threshold: float = 0.0,
+) -> dict[str, float]:
     true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
 
     count = len(true_values)
@@ -51,7 +56,7 @@ def forecast_metrics(y_true: Sequence[float], y_pred: Sequence[float]) -> dict[s
         error = true_val - pred_val
         abs_error_sum += abs(error)
         squared_error_sum += error ** 2
-        matching_directions += int((true_val > 0.0) == (pred_val > 0.0))
+        matching_directions += int((true_val > positive_threshold) == (pred_val > positive_threshold))
     
     return {
         METRIC_MAE: float(abs_error_sum / count),

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -41,10 +41,22 @@ def direction_accuracy(
 
 def forecast_metrics(y_true: Sequence[float], y_pred: Sequence[float]) -> dict[str, float]:
     true_values, pred_values = _coerce_and_validate_inputs(y_true, y_pred)
+
+    count = len(true_values)
+    abs_error_sum = 0.0
+    squared_error_sum = 0.0
+    matching_directions = 0
+    
+    for true_val, pred_val in zip(true_values, pred_values):
+        error = true_val - pred_val
+        abs_error_sum += abs(error)
+        squared_error_sum += error ** 2
+        matching_directions += int((true_val > 0.0) == (pred_val > 0.0))
+    
     return {
-        METRIC_MAE: mean_absolute_error(true_values, pred_values),
-        METRIC_RMSE: root_mean_squared_error(true_values, pred_values),
-        METRIC_DIRECTION_ACCURACY: direction_accuracy(true_values, pred_values),
+        METRIC_MAE: float(abs_error_sum / count),
+        METRIC_RMSE: float(math.sqrt(squared_error_sum / count)),
+        METRIC_DIRECTION_ACCURACY: float(matching_directions / count),
     }
 
 

--- a/src/finsight/infrastructure/ml/sklearn/baseline.py
+++ b/src/finsight/infrastructure/ml/sklearn/baseline.py
@@ -5,6 +5,7 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 
+from finsight.domain.metrics import forecast_metrics
 from finsight.domain.ports import ModelPort
 
 SUPPORTED_MODEL_TYPES = ("naive_zero", "naive_mean")
@@ -42,17 +43,7 @@ class NaiveBaselineModel(ModelPort):
         else:
             y_pred = np.full_like(y_test, fill_value=float(np.mean(y_train)), dtype=float)
 
-        abs_errors = np.abs(y_test - y_pred)
-        sq_errors = np.square(y_test - y_pred)
-
-        y_pred_dir = (y_pred > 0).astype(int)
-        y_true_dir = (y_test > 0).astype(int)
-
-        metrics = {
-            "mae": float(np.mean(abs_errors)),
-            "rmse": float(np.sqrt(np.mean(sq_errors))),
-            "direction_accuracy": float(np.mean(y_pred_dir == y_true_dir)),
-        }
+        metrics = forecast_metrics(y_true=y_test, y_pred=y_pred)
 
         pred_cols = [col for col in id_columns if col in test_df.columns]
         predictions = test_df[pred_cols].copy() if pred_cols else pd.DataFrame(index=test_df.index)

--- a/src/finsight/infrastructure/ml/sklearn/baseline.py
+++ b/src/finsight/infrastructure/ml/sklearn/baseline.py
@@ -43,7 +43,7 @@ class NaiveBaselineModel(ModelPort):
         else:
             y_pred = np.full_like(y_test, fill_value=float(np.mean(y_train)), dtype=float)
 
-        metrics = forecast_metrics(y_true=y_test, y_pred=y_pred)
+        metrics = forecast_metrics(y_true=y_test.tolist(), y_pred=y_pred.tolist())
 
         pred_cols = [col for col in id_columns if col in test_df.columns]
         predictions = test_df[pred_cols].copy() if pred_cols else pd.DataFrame(index=test_df.index)

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -10,6 +10,7 @@ import finsight.application.use_cases.train_model as train_model_module
 from finsight.application.use_cases.fetch_market_data import FetchMarketData, FetchMarketDataRequest
 from finsight.application.use_cases.train_model import TrainModel, TrainModelRequest
 from finsight.domain.entities import OHLCVSeries
+from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
 from finsight.domain.value_objects import DateRange, Interval, Ticker
 from finsight.infrastructure.features import PandasFeatureStore
 from finsight.infrastructure.ml.sklearn import NaiveBaselineModel
@@ -142,10 +143,12 @@ def test_execute_writes_artifacts_and_applies_unique_run_dir_suffix(tmp_path, mo
 
         assert metrics_json["n_train"] > 0
         assert metrics_json["n_test"] > 0
+        assert set(SUPPORTED_METRIC_NAMES).issubset(metrics_json)
         assert {"date", "ticker", "y_true", "y_pred"}.issubset(predictions_df.columns)
 
         assert response.metrics[model_type]["n_train"] == metrics_json["n_train"]
         assert response.metrics[model_type]["n_test"] == metrics_json["n_test"]
+        assert set(SUPPORTED_METRIC_NAMES).issubset(response.metrics[model_type])
 
 
 def test_execute_rejects_unsupported_model_types_from_model_port(tmp_path) -> None:

--- a/tests/unit/application/use_cases/test_train_model_naive.py
+++ b/tests/unit/application/use_cases/test_train_model_naive.py
@@ -8,6 +8,7 @@ from finsight.application.use_cases.train_model import (
     _validate_model_types,
     _validate_supported_model_types,
 )
+from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
 from finsight.infrastructure.features import TimeSplitPolicy
 from finsight.infrastructure.ml.sklearn import NaiveBaselineModel
 
@@ -71,7 +72,7 @@ def test_naive_baseline_model_predictions_and_metrics() -> None:
     assert np.allclose(mean_predictions["y_pred"].to_numpy(), expected_mean)
 
     for metrics, predictions in ((zero_metrics, zero_predictions), (mean_metrics, mean_predictions)):
-        assert {"mae", "rmse", "direction_accuracy"}.issubset(metrics.keys())
+        assert set(SUPPORTED_METRIC_NAMES).issubset(metrics.keys())
         assert 0.0 <= metrics["direction_accuracy"] <= 1.0
         assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
         assert len(predictions) == len(test_df)

--- a/tests/unit/application/use_cases/test_train_model_naive.py
+++ b/tests/unit/application/use_cases/test_train_model_naive.py
@@ -8,7 +8,7 @@ from finsight.application.use_cases.train_model import (
     _validate_model_types,
     _validate_supported_model_types,
 )
-from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
+from finsight.domain.metrics import SUPPORTED_METRIC_NAMES, METRIC_DIRECTION_ACCURACY
 from finsight.infrastructure.features import TimeSplitPolicy
 from finsight.infrastructure.ml.sklearn import NaiveBaselineModel
 
@@ -73,7 +73,7 @@ def test_naive_baseline_model_predictions_and_metrics() -> None:
 
     for metrics, predictions in ((zero_metrics, zero_predictions), (mean_metrics, mean_predictions)):
         assert set(SUPPORTED_METRIC_NAMES).issubset(metrics.keys())
-        assert 0.0 <= metrics["direction_accuracy"] <= 1.0
+        assert 0.0 <= metrics[METRIC_DIRECTION_ACCURACY] <= 1.0
         assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
         assert len(predictions) == len(test_df)
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,6 +1,8 @@
 import pytest
 
-from finsight.cli.main import _build_parser
+import finsight.cli.main as cli_main
+from finsight.cli.main import _build_parser, _run_train
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
 
 
 def test_train_parser_accepts_train_without_tickers_arg() -> None:
@@ -24,5 +26,38 @@ def test_train_parser_rejects_interval_arg() -> None:
 
     with pytest.raises(SystemExit):
         parser.parse_args(["train", "--cutoff", "2025-06-01", "--interval", "1d"])
+
+
+def test_run_train_prints_metrics_using_canonical_metric_keys(monkeypatch, capsys) -> None:
+    class _StubTrainModel:
+        @staticmethod
+        def execute(_request):
+            return type(
+                "Response",
+                (),
+                {
+                    "run_dirs": {"naive_zero": "artifacts/runs/example"},
+                    "metrics": {
+                        "naive_zero": {
+                            METRIC_MAE: 0.1,
+                            METRIC_RMSE: 0.2,
+                            METRIC_DIRECTION_ACCURACY: 0.75,
+                        }
+                    },
+                },
+            )()
+
+    class _StubContainer:
+        train_model = _StubTrainModel()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["train", "--cutoff", "2025-06-01"])
+    exit_code = _run_train(args)
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "[naive_zero] run_dir=artifacts/runs/example" in captured
+    assert "MAE=0.100000 RMSE=0.200000 DirectionAcc=0.7500" in captured
 
 

--- a/tests/unit/domain/test_metrics.py
+++ b/tests/unit/domain/test_metrics.py
@@ -56,6 +56,15 @@ def test_forecast_metrics_returns_canonical_metric_keys() -> None:
     assert metrics[METRIC_DIRECTION_ACCURACY] == pytest.approx(2 / 3)
 
 
+def test_forecast_metrics_allows_custom_direction_threshold() -> None:
+    y_true = [0.01, 0.03, 0.00]
+    y_pred = [0.04, -0.01, 0.00]
+
+    metrics = forecast_metrics(y_true, y_pred, positive_threshold=0.02)
+
+    assert metrics[METRIC_DIRECTION_ACCURACY] == pytest.approx(1 / 3)
+
+
 @pytest.mark.parametrize(
     ("y_true", "y_pred"),
     [

--- a/tests/unit/domain/test_metrics.py
+++ b/tests/unit/domain/test_metrics.py
@@ -1,0 +1,101 @@
+import math
+
+import pytest
+
+from finsight.domain.metrics import (
+    METRIC_DIRECTION_ACCURACY,
+    METRIC_MAE,
+    METRIC_RMSE,
+    SUPPORTED_METRIC_NAMES,
+    direction_accuracy,
+    forecast_metrics,
+    mean_absolute_error,
+    root_mean_squared_error,
+)
+
+
+def test_mean_absolute_error() -> None:
+    y_true = [0.10, -0.20, 0.30]
+    y_pred = [0.00, -0.10, 0.20]
+
+    assert mean_absolute_error(y_true, y_pred) == pytest.approx(0.10)
+
+
+def test_root_mean_squared_error() -> None:
+    y_true = [0.10, -0.20, 0.30]
+    y_pred = [0.00, -0.10, 0.20]
+
+    expected_rmse = math.sqrt((0.01 + 0.01 + 0.01) / 3)
+    assert root_mean_squared_error(y_true, y_pred) == pytest.approx(expected_rmse)
+
+
+def test_direction_accuracy_with_default_threshold() -> None:
+    y_true = [0.10, -0.20, 0.00, 0.30]
+    y_pred = [0.05, 0.10, -0.01, -0.20]
+
+    # Matches on items 0 and 2 when using the existing > 0 directional convention.
+    assert direction_accuracy(y_true, y_pred) == pytest.approx(0.5)
+
+
+def test_direction_accuracy_allows_custom_threshold() -> None:
+    y_true = [0.01, 0.03, 0.00]
+    y_pred = [0.04, -0.01, 0.00]
+
+    assert direction_accuracy(y_true, y_pred, positive_threshold=0.02) == pytest.approx(1 / 3)
+
+
+def test_forecast_metrics_returns_canonical_metric_keys() -> None:
+    y_true = [0.10, -0.20, 0.30]
+    y_pred = [0.00, -0.10, 0.20]
+
+    metrics = forecast_metrics(y_true, y_pred)
+
+    assert tuple(metrics.keys()) == SUPPORTED_METRIC_NAMES
+    assert metrics[METRIC_MAE] == pytest.approx(0.10)
+    assert metrics[METRIC_RMSE] == pytest.approx(math.sqrt((0.01 + 0.01 + 0.01) / 3))
+    assert metrics[METRIC_DIRECTION_ACCURACY] == pytest.approx(2 / 3)
+
+
+@pytest.mark.parametrize(
+    ("y_true", "y_pred"),
+    [
+        ([], []),
+        ([0.1], []),
+        ([], [0.1]),
+    ],
+)
+def test_metric_functions_reject_empty_inputs(y_true: list[float], y_pred: list[float]) -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        mean_absolute_error(y_true, y_pred)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        root_mean_squared_error(y_true, y_pred)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        direction_accuracy(y_true, y_pred)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        forecast_metrics(y_true, y_pred)
+
+
+@pytest.mark.parametrize(
+    ("y_true", "y_pred"),
+    [
+        ([0.1], [0.1, 0.2]),
+        ([0.1, 0.2], [0.1]),
+    ],
+)
+def test_metric_functions_reject_length_mismatch(y_true: list[float], y_pred: list[float]) -> None:
+    with pytest.raises(ValueError, match="same length"):
+        mean_absolute_error(y_true, y_pred)
+
+    with pytest.raises(ValueError, match="same length"):
+        root_mean_squared_error(y_true, y_pred)
+
+    with pytest.raises(ValueError, match="same length"):
+        direction_accuracy(y_true, y_pred)
+
+    with pytest.raises(ValueError, match="same length"):
+        forecast_metrics(y_true, y_pred)
+
+


### PR DESCRIPTION
This pull request introduces a new set of core forecasting metric functions to the `finsight` domain, along with comprehensive unit tests to ensure their correctness and robustness. The main changes include the implementation of standard error metrics, direction accuracy, input validation, and a unified metrics aggregation function.

**New forecasting metrics and utilities:**

* Added implementations for `mean_absolute_error`, `root_mean_squared_error`, and `direction_accuracy` functions, including support for a customizable threshold in direction accuracy.
* Introduced the `forecast_metrics` function to compute and return all supported metrics in a canonical dictionary format.
* Defined canonical metric name constants and the `SUPPORTED_METRIC_NAMES` tuple for consistent referencing and output.
* Added robust input validation to all metric functions to ensure non-empty, equal-length input sequences, raising clear `ValueError` messages on invalid input.

**Testing improvements:**

* Created a new test suite in `test_metrics.py` to verify correct computation, input validation, and edge cases for all metric functions, using `pytest` and parameterized tests for comprehensive coverage.