### PR TITLE
Add model catalog and canonical ids

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,11 +25,20 @@ cache:
 # Model Defaults (UI + app defaults)
 # ====================================
 model_defaults:
-  options:
-    - "x model"
-    - "y model"
-    - "z model"
-  default_model: "x model"
+  catalog:
+    - id: "naive_zero"
+      label: "Naive (Zero)"
+      supports_training: true
+      supports_prediction: true
+    - id: "naive_mean"
+      label: "Naive (Mean)"
+      supports_training: true
+      supports_prediction: true
+    - id: "ridge"
+      label: "Ridge Regression"
+      supports_training: false
+      supports_prediction: false
+  default_model_id: "naive_zero"
   horizon_min: 7
   horizon_max: 90
   default_horizon: 30

--- a/src/finsight/adapters/web_streamlit/views/predict.py
+++ b/src/finsight/adapters/web_streamlit/views/predict.py
@@ -64,18 +64,41 @@ def render():
 
     model_defaults = _SETTINGS.model_defaults
     id_to_label = model_defaults.id_to_label()
-    label_to_id = model_defaults.label_to_id()
-    model_labels = list(model_defaults.labels())
-    default_model_label = id_to_label[model_defaults.default_model_id]
+    prediction_model_ids = list(model_defaults.prediction_model_ids())
+    prediction_model_labels = [id_to_label[model_id] for model_id in prediction_model_ids]
+    has_prediction_models = bool(prediction_model_ids)
+
+    if model_defaults.default_model_id in prediction_model_ids:
+        default_model_id = model_defaults.default_model_id
+    elif prediction_model_ids:
+        default_model_id = prediction_model_ids[0]
+    else:
+        default_model_id = None
+
+    selected_model_id: str | None = None
 
     # TODO: selected_model_id will be passed to the forecast use case.
     with col2:
-        selected_label = st.selectbox(
-            "Choose a prediction model",
-            model_labels,
-            index=model_labels.index(default_model_label),
+        if has_prediction_models:
+            selected_index = prediction_model_ids.index(default_model_id)
+            selected_label = st.selectbox(
+                "Choose a prediction model",
+                prediction_model_labels,
+                index=selected_index,
+            )
+            selected_model_id = prediction_model_ids[prediction_model_labels.index(selected_label)]
+        else:
+            st.selectbox(
+                "Choose a prediction model",
+                ["No prediction-enabled models configured"],
+                index=0,
+                disabled=True,
+            )
+
+    if not has_prediction_models:
+        st.warning(
+            "No prediction-enabled models are configured."
         )
-    selected_model_id = label_to_id[selected_label]
 
     # TODO: horizon will be used by the forecast use case.
     horizon = st.slider(
@@ -88,7 +111,11 @@ def render():
 
     fetch_col, predict_col = st.columns(2)
     fetch_data_button = fetch_col.button("Fetch Historical Data", use_container_width=True)
-    predict_button = predict_col.button("Run Prediction", use_container_width=True)
+    predict_button = predict_col.button(
+        "Run Prediction",
+        use_container_width=True,
+        disabled=not has_prediction_models,
+    )
 
     if fetch_data_button:
         try:
@@ -96,7 +123,7 @@ def render():
         except Exception as e:
             st.error(f"Failed to fetch data: {e}")
 
-    if predict_button:
+    if predict_button and selected_model_id is not None:
         st.info(
             f"Prediction flow is not implemented yet (selected model_id='{selected_model_id}')."
         )

--- a/src/finsight/adapters/web_streamlit/views/predict.py
+++ b/src/finsight/adapters/web_streamlit/views/predict.py
@@ -63,14 +63,19 @@ def render():
         ticker = st.selectbox("Choose a stock ticker", ["AAPL", "GOOGL", "MSFT", "TSLA", "AMZN", "NFLX"])
 
     model_defaults = _SETTINGS.model_defaults
+    id_to_label = model_defaults.id_to_label()
+    label_to_id = model_defaults.label_to_id()
+    model_labels = list(model_defaults.labels())
+    default_model_label = id_to_label[model_defaults.default_model_id]
 
-    # TODO: model_choice will be used by the forecast use case.
+    # TODO: selected_model_id will be passed to the forecast use case.
     with col2:
-        model_choice = st.selectbox(
+        selected_label = st.selectbox(
             "Choose a prediction model",
-            list(model_defaults.options),
-            index=list(model_defaults.options).index(model_defaults.default_model),
+            model_labels,
+            index=model_labels.index(default_model_label),
         )
+    selected_model_id = label_to_id[selected_label]
 
     # TODO: horizon will be used by the forecast use case.
     horizon = st.slider(
@@ -93,5 +98,5 @@ def render():
 
     if predict_button:
         st.info(
-            "Prediction flow is not implemented yet."
+            f"Prediction flow is not implemented yet (selected model_id='{selected_model_id}')."
         )

--- a/src/finsight/adapters/web_streamlit/views/predict.py
+++ b/src/finsight/adapters/web_streamlit/views/predict.py
@@ -60,7 +60,7 @@ def render():
     col1, col2 = st.columns(2)
 
     with col1:
-        ticker = st.selectbox("Choose a stock ticker", ["AAPL", "GOOGL", "MSFT", "TSLA", "AMZN", "NFLX"])
+        ticker = st.selectbox("Choose a stock ticker", list(_SETTINGS.training.training_tickers))
 
     model_defaults = _SETTINGS.model_defaults
     id_to_label = model_defaults.id_to_label()

--- a/src/finsight/application/use_cases/train_model.py
+++ b/src/finsight/application/use_cases/train_model.py
@@ -79,12 +79,21 @@ class TrainModel:
         supported_model_types: tuple[str, ...] | list[str] | None = None,
         default_interval: str = "1d",
     ) -> None:
+        model_supported_model_types = self._as_tuple(model.supported_model_types())
+        configured_supported_model_types = (
+            model_supported_model_types
+            if supported_model_types is None
+            else self._as_tuple(supported_model_types)
+        )
+        _validate_model_types(list(configured_supported_model_types))
+        _validate_supported_model_types(list(configured_supported_model_types), model_supported_model_types)
+
         self._fetch_market_data = fetch_market_data
         self._feature_store = feature_store
         self._model = model
         self._model_registry = model_registry
         self._training_tickers = tuple(training_tickers)
-        self._supported_model_types = tuple(supported_model_types) if supported_model_types is not None else None
+        self._supported_model_types = configured_supported_model_types
         self._default_interval = default_interval
 
     def execute(self, request: TrainModelRequest) -> TrainModelResponse:
@@ -93,11 +102,7 @@ class TrainModel:
 
         tickers = _get_training_tickers(self._training_tickers)
         model_types = _validate_model_types(request.model_types)
-        if self._supported_model_types is None:
-            supported_model_types = self._model.supported_model_types()
-        else:
-            supported_model_types = self._supported_model_types
-        _validate_supported_model_types(model_types, supported_model_types)
+        _validate_supported_model_types(model_types, self._supported_model_types)
         resolved_interval = request.interval or self._default_interval
 
         end_date = _parse_iso_date(request.end) if request.end else date.today()
@@ -205,5 +210,9 @@ class TrainModel:
             metrics[model_type] = enriched_metrics
 
         return TrainModelResponse(run_dirs=run_dirs, metrics=metrics)
+
+    @staticmethod
+    def _as_tuple(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+        return tuple(values)
 
 

--- a/src/finsight/application/use_cases/train_model.py
+++ b/src/finsight/application/use_cases/train_model.py
@@ -76,6 +76,7 @@ class TrainModel:
         model: ModelPort,
         model_registry: ModelRegistryPort,
         training_tickers: tuple[str, ...] | list[str],
+        supported_model_types: tuple[str, ...] | list[str] | None = None,
         default_interval: str = "1d",
     ) -> None:
         self._fetch_market_data = fetch_market_data
@@ -83,6 +84,7 @@ class TrainModel:
         self._model = model
         self._model_registry = model_registry
         self._training_tickers = tuple(training_tickers)
+        self._supported_model_types = tuple(supported_model_types) if supported_model_types is not None else None
         self._default_interval = default_interval
 
     def execute(self, request: TrainModelRequest) -> TrainModelResponse:
@@ -91,7 +93,8 @@ class TrainModel:
 
         tickers = _get_training_tickers(self._training_tickers)
         model_types = _validate_model_types(request.model_types)
-        _validate_supported_model_types(model_types, self._model.supported_model_types())
+        supported_model_types = self._supported_model_types or self._model.supported_model_types()
+        _validate_supported_model_types(model_types, supported_model_types)
         resolved_interval = request.interval or self._default_interval
 
         end_date = _parse_iso_date(request.end) if request.end else date.today()

--- a/src/finsight/application/use_cases/train_model.py
+++ b/src/finsight/application/use_cases/train_model.py
@@ -93,7 +93,10 @@ class TrainModel:
 
         tickers = _get_training_tickers(self._training_tickers)
         model_types = _validate_model_types(request.model_types)
-        supported_model_types = self._supported_model_types or self._model.supported_model_types()
+        if self._supported_model_types is None:
+            supported_model_types = self._model.supported_model_types()
+        else:
+            supported_model_types = self._supported_model_types
         _validate_supported_model_types(model_types, supported_model_types)
         resolved_interval = request.interval or self._default_interval
 

--- a/src/finsight/bootstrap/container.py
+++ b/src/finsight/bootstrap/container.py
@@ -41,6 +41,7 @@ def build_container() -> AppContainer:
         model=model,
         model_registry=model_registry,
         training_tickers=settings.training.training_tickers,
+        supported_model_types=settings.model_defaults.training_model_ids(),
         default_interval=settings.stock_data.default_interval,
     )
 

--- a/src/finsight/cli/main.py
+++ b/src/finsight/cli/main.py
@@ -12,7 +12,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="finsight")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    tickers = ", ".join(get_settings().training.training_tickers)
+    settings = get_settings()
+    tickers = ", ".join(settings.training.training_tickers)
+    training_model_ids = list(settings.model_defaults.training_model_ids())
     train_parser = subparsers.add_parser(
         "train",
         help=f"Train/evaluate baseline models on fixed tickers: {tickers}",
@@ -23,8 +25,8 @@ def _build_parser() -> argparse.ArgumentParser:
     train_parser.add_argument(
         "--model-types",
         nargs="+",
-        default=["naive_zero", "naive_mean"],
-        help="Model types to evaluate",
+        default=training_model_ids,
+        help=f"Model IDs to evaluate (defaults: {', '.join(training_model_ids)})",
     )
     train_parser.add_argument(
         "--artifacts-dir",

--- a/src/finsight/config/settings.py
+++ b/src/finsight/config/settings.py
@@ -165,7 +165,7 @@ def _parse_model_catalog(value: Any, default: tuple[ModelCatalogEntry, ...]) -> 
             )
         )
 
-    return tuple(parsed_entries) if parsed_entries else default
+    return tuple(parsed_entries)
 
 
 @lru_cache(maxsize=1)
@@ -203,7 +203,13 @@ def get_settings(config_path: Path | None = None) -> Settings:
         data_ttl_seconds=_as_int(cache_raw.get("data_ttl_seconds"), 900, minimum=1),
     )
 
-    catalog = _parse_model_catalog(model_raw.get("catalog"), DEFAULT_MODEL_CATALOG)
+    raw_catalog = model_raw.get("catalog")
+    if raw_catalog is None:
+        catalog = _parse_model_catalog(raw_catalog, DEFAULT_MODEL_CATALOG)
+    else:
+        # When a catalog is explicitly provided (even if empty/invalid), do not
+        # fall back to DEFAULT_MODEL_CATALOG so that validation can detect it.
+        catalog = _parse_model_catalog(raw_catalog, ())
     if not catalog:
         raise ValueError("model_defaults.catalog must contain at least one model entry.")
 

--- a/src/finsight/config/settings.py
+++ b/src/finsight/config/settings.py
@@ -29,16 +29,45 @@ class CacheSettings:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelCatalogEntry:
+    id: str
+    label: str
+    supports_training: bool = True
+    supports_prediction: bool = True
+
+
+DEFAULT_MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
+    ModelCatalogEntry(id="naive_zero", label="Naive (Zero)", supports_training=True, supports_prediction=True),
+    ModelCatalogEntry(id="naive_mean", label="Naive (Mean)", supports_training=True, supports_prediction=True),
+    ModelCatalogEntry(id="ridge", label="Ridge Regression", supports_training=False, supports_prediction=False),
+)
+
+
+@dataclass(frozen=True, slots=True)
 class ModelDefaults:
-    options: tuple[str, ...] = (
-        "Linear Regression",
-        "Random Forest",
-        "LSTM (Neural Network)",
-    )
-    default_model: str = "Linear Regression"
+    catalog: tuple[ModelCatalogEntry, ...] = DEFAULT_MODEL_CATALOG
+    default_model_id: str = "naive_zero"
     horizon_min: int = 7
     horizon_max: int = 90
     default_horizon: int = 30
+
+    def model_ids(self) -> tuple[str, ...]:
+        return tuple(entry.id for entry in self.catalog)
+
+    def labels(self) -> tuple[str, ...]:
+        return tuple(entry.label for entry in self.catalog)
+
+    def id_to_label(self) -> dict[str, str]:
+        return {entry.id: entry.label for entry in self.catalog}
+
+    def label_to_id(self) -> dict[str, str]:
+        return {entry.label: entry.id for entry in self.catalog}
+
+    def training_model_ids(self) -> tuple[str, ...]:
+        return tuple(entry.id for entry in self.catalog if entry.supports_training)
+
+    def prediction_model_ids(self) -> tuple[str, ...]:
+        return tuple(entry.id for entry in self.catalog if entry.supports_prediction)
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,6 +145,29 @@ def _as_tuple_of_str(value: Any, default: tuple[str, ...]) -> tuple[str, ...]:
     return default
 
 
+def _parse_model_catalog(value: Any, default: tuple[ModelCatalogEntry, ...]) -> tuple[ModelCatalogEntry, ...]:
+    if not isinstance(value, (list, tuple)):
+        return default
+
+    parsed_entries: list[ModelCatalogEntry] = []
+    for raw_entry in value:
+        entry_raw = _as_mapping(raw_entry)
+        model_id = _as_str(entry_raw.get("id"), "")
+        label = _as_str(entry_raw.get("label"), "")
+        if not model_id:
+            continue
+        parsed_entries.append(
+            ModelCatalogEntry(
+                id=model_id,
+                label=label or model_id,
+                supports_training=_as_bool(entry_raw.get("supports_training"), True),
+                supports_prediction=_as_bool(entry_raw.get("supports_prediction"), True),
+            )
+        )
+
+    return tuple(parsed_entries) if parsed_entries else default
+
+
 @lru_cache(maxsize=1)
 def get_settings(config_path: Path | None = None) -> Settings:
     path = config_path or _default_config_path()
@@ -151,25 +203,31 @@ def get_settings(config_path: Path | None = None) -> Settings:
         data_ttl_seconds=_as_int(cache_raw.get("data_ttl_seconds"), 900, minimum=1),
     )
 
-    options = _as_tuple_of_str(
-        model_raw.get("options"),
-        (
-            "Linear Regression",
-            "Random Forest",
-            "LSTM (Neural Network)",
-        ),
-    )
-    default_model = _as_str(model_raw.get("default_model"), options[0])
-    if default_model not in options:
-        default_model = options[0]
+    catalog = _parse_model_catalog(model_raw.get("catalog"), DEFAULT_MODEL_CATALOG)
+    if not catalog:
+        raise ValueError("model_defaults.catalog must contain at least one model entry.")
+
+    model_ids = tuple(entry.id for entry in catalog)
+    if len(set(model_ids)) != len(model_ids):
+        raise ValueError("model_defaults.catalog contains duplicate model ids.")
+
+    labels = tuple(entry.label for entry in catalog)
+    if len(set(labels)) != len(labels):
+        raise ValueError("model_defaults.catalog contains duplicate model labels.")
+
+    default_model_id = _as_str(model_raw.get("default_model_id"), model_ids[0])
+    if default_model_id not in model_ids:
+        raise ValueError(
+            f"Unknown model_defaults.default_model_id '{default_model_id}'. Supported model ids: {model_ids}."
+        )
 
     horizon_min = _as_int(model_raw.get("horizon_min"), 7, minimum=1)
     horizon_max = _as_int(model_raw.get("horizon_max"), 90, minimum=horizon_min)
     default_horizon = _as_int(model_raw.get("default_horizon"), 30, minimum=horizon_min, maximum=horizon_max)
 
     model_settings = ModelDefaults(
-        options=options,
-        default_model=default_model,
+        catalog=catalog,
+        default_model_id=default_model_id,
         horizon_min=horizon_min,
         horizon_max=horizon_max,
         default_horizon=default_horizon,

--- a/src/finsight/config/settings.py
+++ b/src/finsight/config/settings.py
@@ -203,13 +203,12 @@ def get_settings(config_path: Path | None = None) -> Settings:
         data_ttl_seconds=_as_int(cache_raw.get("data_ttl_seconds"), 900, minimum=1),
     )
 
-    raw_catalog = model_raw.get("catalog")
-    if raw_catalog is None:
-        catalog = _parse_model_catalog(raw_catalog, DEFAULT_MODEL_CATALOG)
-    else:
+    if "catalog" in model_raw:
         # When a catalog is explicitly provided (even if empty/invalid), do not
         # fall back to DEFAULT_MODEL_CATALOG so that validation can detect it.
-        catalog = _parse_model_catalog(raw_catalog, ())
+        catalog = _parse_model_catalog(model_raw.get("catalog"), ())
+    else:
+        catalog = DEFAULT_MODEL_CATALOG
     if not catalog:
         raise ValueError("model_defaults.catalog must contain at least one model entry.")
 
@@ -225,6 +224,13 @@ def get_settings(config_path: Path | None = None) -> Settings:
     if default_model_id not in model_ids:
         raise ValueError(
             f"Unknown model_defaults.default_model_id '{default_model_id}'. Supported model ids: {model_ids}."
+        )
+
+    training_model_ids = tuple(entry.id for entry in catalog if entry.supports_training)
+    if not training_model_ids:
+        raise ValueError(
+            "model_defaults.catalog must enable training for at least one model "
+            "(set supports_training=true)."
         )
 
     horizon_min = _as_int(model_raw.get("horizon_min"), 7, minimum=1)

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -202,4 +202,16 @@ def test_execute_rejects_model_type_not_enabled_by_configuration(tmp_path) -> No
     assert stub.calls == []
 
 
+def test_constructor_rejects_configured_model_types_not_supported_by_model_port() -> None:
+    with pytest.raises(ValueError, match=r"Unsupported model type\(s\)"):
+        TrainModel(
+            fetch_market_data=cast(FetchMarketData, cast(object, _StubFetchMarketData({}))),
+            feature_store=PandasFeatureStore(),
+            model=NaiveBaselineModel(),
+            model_registry=LocalFileModelRegistry(),
+            training_tickers=("AAPL",),
+            supported_model_types=("ridge",),
+        )
+
+
 

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -176,4 +176,30 @@ def test_execute_rejects_unsupported_model_types_from_model_port(tmp_path) -> No
     assert stub.calls == []
 
 
+def test_execute_rejects_model_type_not_enabled_by_configuration(tmp_path) -> None:
+    tickers = ("AAPL",)
+    stub = _StubFetchMarketData({ticker: _make_ohlcv_series(ticker) for ticker in tickers})
+    train_model = TrainModel(
+        fetch_market_data=cast(FetchMarketData, cast(object, stub)),
+        feature_store=PandasFeatureStore(),
+        model=NaiveBaselineModel(),
+        model_registry=LocalFileModelRegistry(),
+        training_tickers=tickers,
+        supported_model_types=("naive_zero",),
+    )
+
+    with pytest.raises(ValueError, match=r"Unsupported model type\(s\)"):
+        train_model.execute(
+            TrainModelRequest(
+                cutoff_date="2025-06-01",
+                years=2,
+                end="2026-03-17",
+                model_types=["naive_mean"],
+                artifacts_dir=str(tmp_path / "runs"),
+            )
+        )
+
+    assert stub.calls == []
+
+
 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from finsight.config.settings import get_settings
 
 
@@ -27,4 +29,59 @@ def test_get_settings_uses_default_training_tickers_when_missing(tmp_path: Path)
     settings = get_settings(config_path)
 
     assert settings.training.training_tickers == ("AAPL", "JPM", "XOM", "KO", "TSLA")
+
+
+def test_get_settings_parses_model_catalog_with_default_model_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model_defaults:
+  catalog:
+    - id: naive_zero
+      label: Naive (Zero)
+      supports_training: true
+      supports_prediction: true
+    - id: ridge
+      label: Ridge Regression
+      supports_training: false
+      supports_prediction: true
+  default_model_id: naive_zero
+""".strip(),
+        encoding="utf-8",
+    )
+
+    settings = get_settings(config_path)
+
+    assert settings.model_defaults.model_ids() == ("naive_zero", "ridge")
+    assert settings.model_defaults.labels() == ("Naive (Zero)", "Ridge Regression")
+    assert settings.model_defaults.default_model_id == "naive_zero"
+    assert settings.model_defaults.training_model_ids() == ("naive_zero",)
+
+
+def test_get_settings_rejects_unknown_default_model_id(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model_defaults:
+  catalog:
+    - id: naive_zero
+      label: Naive (Zero)
+  default_model_id: does_not_exist
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unknown model_defaults.default_model_id"):
+        get_settings(config_path)
+
+
+def test_get_settings_uses_default_model_catalog_when_missing(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("stock_data: {}", encoding="utf-8")
+
+    settings = get_settings(config_path)
+
+    assert settings.model_defaults.model_ids() == ("naive_zero", "naive_mean", "ridge")
+    assert settings.model_defaults.default_model_id == "naive_zero"
+
 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -75,6 +75,39 @@ model_defaults:
         get_settings(config_path)
 
 
+def test_get_settings_rejects_explicit_null_model_catalog(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model_defaults:
+  catalog: null
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="model_defaults.catalog must contain at least one model entry"):
+        get_settings(config_path)
+
+
+def test_get_settings_rejects_model_catalog_without_training_enabled_models(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+model_defaults:
+  catalog:
+    - id: ridge
+      label: Ridge Regression
+      supports_training: false
+      supports_prediction: true
+  default_model_id: ridge
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must enable training for at least one model"):
+        get_settings(config_path)
+
+
 def test_get_settings_uses_default_model_catalog_when_missing(tmp_path: Path) -> None:
     config_path = tmp_path / "config.yaml"
     config_path.write_text("stock_data: {}", encoding="utf-8")


### PR DESCRIPTION
This pull request introduces a significant refactor of how prediction models are configured, selected, and validated throughout the application. The old approach of using simple string lists for model options has been replaced with a structured model catalog, enabling more robust validation, configurability, and future extensibility. The changes affect configuration, settings parsing, CLI defaults, use case validation, and the Streamlit UI, and are covered by new and updated unit tests.

**Configuration and Settings Refactor:**

- Replaced the flat `options`/`default_model` entries in `model_defaults` with a structured `catalog` and `default_model_id`, where each model entry specifies its ID, label, and support for training/prediction. This enables precise model selection and validation.
- Added parsing logic for the new catalog format, including checks for duplicate IDs/labels and validation that the default model exists in the catalog.

**Application and CLI Integration:**

- Updated the CLI to use the new model catalog, setting training defaults and help text based on the catalog entries rather than hardcoded values.
- The DI container now injects the correct list of training-enabled model IDs into the training use case, derived from the catalog.

**Use Case and Validation Logic:**

- The `TrainModel` use case now accepts a configurable list of supported model types (from settings), and validates requests against this list.
- Added a new unit test to ensure unsupported model types are correctly rejected if not enabled in the configuration.

**Streamlit UI Improvements:**

- The model selection UI now displays labels from the catalog and maps user selections to model IDs, ensuring consistency with configuration and backend logic. 

**Testing and Validation:**

- Added comprehensive tests for settings parsing, catalog validation, and error handling for misconfigured model catalogs or unknown default model IDs. 

These changes lay the groundwork for more flexible model management and pave the way for future extensibility in model selection and feature toggling.