### PR TITLE
Add run manifest contract

### DIFF
--- a/src/finsight/application/contracts/__init__.py
+++ b/src/finsight/application/contracts/__init__.py
@@ -1,0 +1,7 @@
+from finsight.application.contracts.run_manifest import (
+    REQUIRED_MANIFEST_KEYS,
+    build_run_manifest,
+    validate_run_manifest,
+)
+
+__all__ = ["REQUIRED_MANIFEST_KEYS", "build_run_manifest", "validate_run_manifest"]

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -54,7 +54,8 @@ def validate_run_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     if unexpected:
         raise ValueError(f"Manifest contains unexpected key(s): {unexpected}.")
 
-    # Only retain keys that are part of the standardized manifest schema.
+    # After rejecting unexpected keys, build a payload containing only keys
+    # from the standardized manifest schema.
     payload: dict[str, Any] = {key: raw_payload[key] for key in REQUIRED_MANIFEST_KEYS}
     _require_non_empty_str(payload["run_id"], key="run_id")
     _require_non_empty_str(payload["model_id"], key="model_id")

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -44,12 +44,18 @@ def build_run_manifest(
 
 
 def validate_run_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
-    payload = dict(manifest)
+    raw_payload = dict(manifest)
 
-    missing = [key for key in REQUIRED_MANIFEST_KEYS if key not in payload]
+    missing = [key for key in REQUIRED_MANIFEST_KEYS if key not in raw_payload]
     if missing:
         raise ValueError(f"Manifest is missing required key(s): {missing}.")
 
+    unexpected = [key for key in raw_payload if key not in REQUIRED_MANIFEST_KEYS]
+    if unexpected:
+        raise ValueError(f"Manifest contains unexpected key(s): {unexpected}.")
+
+    # Only retain keys that are part of the standardized manifest schema.
+    payload: dict[str, Any] = {key: raw_payload[key] for key in REQUIRED_MANIFEST_KEYS}
     _require_non_empty_str(payload["run_id"], key="run_id")
     _require_non_empty_str(payload["model_id"], key="model_id")
     _require_non_empty_str(payload["target"], key="target")

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -128,10 +128,9 @@ def _require_iso_datetime_z(value: Any, *, key: str) -> None:
     if not isinstance(value, str) or not value.endswith("Z"):
         raise TypeError(f"Manifest key '{key}' must be a UTC ISO-8601 timestamp ending in 'Z'.")
 
-    normalized = value[:-1] + "+00:00"
     try:
-        datetime.fromisoformat(normalized)
+        datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ")
     except ValueError as exc:
         raise ValueError(
-            f"Manifest key '{key}' must be a valid UTC ISO-8601 timestamp (e.g. 2026-03-29T12:00:00Z)."
+            f"Manifest key '{key}' must be a valid UTC ISO-8601 timestamp in the format YYYY-MM-DDTHH:MM:SSZ."
         ) from exc

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date, datetime
+from typing import Any
+
+REQUIRED_MANIFEST_KEYS: tuple[str, ...] = (
+    "run_id",
+    "model_id",
+    "feature_columns",
+    "target",
+    "split_policy",
+    "dates",
+    "params",
+    "artifact_paths",
+    "created_at",
+)
+
+
+def build_run_manifest(
+    *,
+    run_id: str,
+    model_id: str,
+    feature_columns: Sequence[str],
+    target: str,
+    split_policy: Mapping[str, Any],
+    dates: Mapping[str, Any],
+    params: Mapping[str, Any],
+    artifact_paths: Mapping[str, Any],
+    created_at: str,
+) -> dict[str, Any]:
+    manifest = {
+        "run_id": run_id,
+        "model_id": model_id,
+        "feature_columns": list(feature_columns),
+        "target": target,
+        "split_policy": dict(split_policy),
+        "dates": dict(dates),
+        "params": dict(params),
+        "artifact_paths": dict(artifact_paths),
+        "created_at": created_at,
+    }
+    return validate_run_manifest(manifest)
+
+
+def validate_run_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(manifest)
+
+    missing = [key for key in REQUIRED_MANIFEST_KEYS if key not in payload]
+    if missing:
+        raise ValueError(f"Manifest is missing required key(s): {missing}.")
+
+    _require_non_empty_str(payload["run_id"], key="run_id")
+    _require_non_empty_str(payload["model_id"], key="model_id")
+    _require_non_empty_str(payload["target"], key="target")
+    _require_iso_datetime_z(payload["created_at"], key="created_at")
+
+    feature_columns = payload["feature_columns"]
+    if not isinstance(feature_columns, list) or not feature_columns:
+        raise TypeError("Manifest key 'feature_columns' must be a non-empty list.")
+    if any(not isinstance(col, str) or not col.strip() for col in feature_columns):
+        raise TypeError("Manifest key 'feature_columns' must contain non-empty strings.")
+    if len(set(feature_columns)) != len(feature_columns):
+        raise ValueError("Manifest key 'feature_columns' must not contain duplicates.")
+
+    split_policy = _require_mapping(payload["split_policy"], key="split_policy")
+    for key in ("name", "cutoff_date", "date_col", "inclusive_test"):
+        if key not in split_policy:
+            raise ValueError(f"Manifest key 'split_policy' is missing '{key}'.")
+    _require_non_empty_str(split_policy["name"], key="split_policy.name")
+    _require_non_empty_str(split_policy["date_col"], key="split_policy.date_col")
+    _require_iso_date(split_policy["cutoff_date"], key="split_policy.cutoff_date")
+    if not isinstance(split_policy["inclusive_test"], bool):
+        raise TypeError("Manifest key 'split_policy.inclusive_test' must be a boolean.")
+
+    dates = _require_mapping(payload["dates"], key="dates")
+    for key in (
+        "requested_start",
+        "requested_end",
+        "train_min",
+        "train_max",
+        "test_min",
+        "test_max",
+    ):
+        if key not in dates:
+            raise ValueError(f"Manifest key 'dates' is missing '{key}'.")
+        _require_iso_date(dates[key], key=f"dates.{key}")
+
+    _require_mapping(payload["params"], key="params")
+
+    artifact_paths = _require_mapping(payload["artifact_paths"], key="artifact_paths")
+    for key in ("run_dir", "metrics", "manifest", "predictions"):
+        if key not in artifact_paths:
+            raise ValueError(f"Manifest key 'artifact_paths' is missing '{key}'.")
+        _require_non_empty_str(artifact_paths[key], key=f"artifact_paths.{key}")
+
+    return payload
+
+
+def _require_mapping(value: Any, *, key: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Manifest key '{key}' must be a mapping.")
+    return value
+
+
+def _require_non_empty_str(value: Any, *, key: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(f"Manifest key '{key}' must be a non-empty string.")
+
+
+def _require_iso_date(value: Any, *, key: str) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"Manifest key '{key}' must be an ISO date string.")
+    try:
+        date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"Manifest key '{key}' must be an ISO date string (YYYY-MM-DD).") from exc
+
+
+def _require_iso_datetime_z(value: Any, *, key: str) -> None:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise TypeError(f"Manifest key '{key}' must be a UTC ISO-8601 timestamp ending in 'Z'.")
+
+    normalized = value[:-1] + "+00:00"
+    try:
+        datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(
+            f"Manifest key '{key}' must be a valid UTC ISO-8601 timestamp (e.g. 2026-03-29T12:00:00Z)."
+        ) from exc

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -32,7 +32,7 @@ def build_run_manifest(
     manifest = {
         "run_id": run_id,
         "model_id": model_id,
-        "feature_columns": list(feature_columns),
+        "feature_columns": feature_columns,
         "target": target,
         "split_policy": dict(split_policy),
         "dates": dict(dates),

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -75,6 +75,7 @@ def validate_run_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     _require_iso_date(split_policy["cutoff_date"], key="split_policy.cutoff_date")
     if not isinstance(split_policy["inclusive_test"], bool):
         raise TypeError("Manifest key 'split_policy.inclusive_test' must be a boolean.")
+    payload["split_policy"] = dict(split_policy)
 
     dates = _require_mapping(payload["dates"], key="dates")
     for key in (
@@ -88,14 +89,17 @@ def validate_run_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
         if key not in dates:
             raise ValueError(f"Manifest key 'dates' is missing '{key}'.")
         _require_iso_date(dates[key], key=f"dates.{key}")
+    payload["dates"] = dict(dates)
 
-    _require_mapping(payload["params"], key="params")
+    params = _require_mapping(payload["params"], key="params")
+    payload["params"] = dict(params)
 
     artifact_paths = _require_mapping(payload["artifact_paths"], key="artifact_paths")
     for key in ("run_dir", "metrics", "manifest", "predictions"):
         if key not in artifact_paths:
             raise ValueError(f"Manifest key 'artifact_paths' is missing '{key}'.")
         _require_non_empty_str(artifact_paths[key], key=f"artifact_paths.{key}")
+    payload["artifact_paths"] = dict(artifact_paths)
 
     return payload
 

--- a/src/finsight/application/contracts/run_manifest.py
+++ b/src/finsight/application/contracts/run_manifest.py
@@ -56,12 +56,15 @@ def validate_run_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
     _require_iso_datetime_z(payload["created_at"], key="created_at")
 
     feature_columns = payload["feature_columns"]
-    if not isinstance(feature_columns, list) or not feature_columns:
-        raise TypeError("Manifest key 'feature_columns' must be a non-empty list.")
+    if isinstance(feature_columns, (str, bytes)) or not isinstance(feature_columns, Sequence):
+        raise TypeError("Manifest key 'feature_columns' must be a non-empty sequence of strings.")
+    if not feature_columns:
+        raise TypeError("Manifest key 'feature_columns' must be a non-empty sequence of strings.")
     if any(not isinstance(col, str) or not col.strip() for col in feature_columns):
         raise TypeError("Manifest key 'feature_columns' must contain non-empty strings.")
     if len(set(feature_columns)) != len(feature_columns):
         raise ValueError("Manifest key 'feature_columns' must not contain duplicates.")
+    payload["feature_columns"] = list(feature_columns)
 
     split_policy = _require_mapping(payload["split_policy"], key="split_policy")
     for key in ("name", "cutoff_date", "date_col", "inclusive_test"):

--- a/src/finsight/application/use_cases/train_model.py
+++ b/src/finsight/application/use_cases/train_model.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
+from finsight.application.contracts import build_run_manifest
 from finsight.application.use_cases.fetch_market_data import FetchMarketData, FetchMarketDataRequest
 from finsight.domain.ports import FeatureStorePort, ModelPort, ModelRegistryPort
 
@@ -173,25 +174,39 @@ class TrainModel:
                 "test_max_date": test_max_date,
             }
 
-            metadata = {
-                "run_id": run_dir_name,
-                "created_at_utc": created_at_utc,
-                "model_type": model_type,
-                "tickers": tickers,
-                "interval": resolved_interval,
-                "years": int(request.years),
-                "end": request.end or end_date.isoformat(),
-                "cutoff_date": request.cutoff_date,
-                "horizon": "1d",
-                "feature_columns": feature_columns,
-                "target_column": TARGET_COLUMN,
-                "n_train": n_train,
-                "n_test": n_test,
-                "train_min_date": train_min_date,
-                "train_max_date": train_max_date,
-                "test_min_date": test_min_date,
-                "test_max_date": test_max_date,
-            }
+            metadata = build_run_manifest(
+                run_id=run_dir_name,
+                model_id=model_type,
+                feature_columns=feature_columns,
+                target=TARGET_COLUMN,
+                split_policy={
+                    "name": "time_split",
+                    "cutoff_date": request.cutoff_date,
+                    "date_col": "date",
+                    "inclusive_test": True,
+                },
+                dates={
+                    "requested_start": start_date.isoformat(),
+                    "requested_end": request.end or end_date.isoformat(),
+                    "train_min": train_min_date,
+                    "train_max": train_max_date,
+                    "test_min": test_min_date,
+                    "test_max": test_max_date,
+                },
+                params={
+                    "tickers": tickers,
+                    "interval": resolved_interval,
+                    "years": int(request.years),
+                    "horizon": "1d",
+                },
+                artifact_paths={
+                    "run_dir": run_dir,
+                    "metrics": str(Path(run_dir) / "metrics.json"),
+                    "manifest": str(Path(run_dir) / "manifest.json"),
+                    "predictions": str(Path(run_dir) / "predictions.csv"),
+                },
+                created_at=created_at_utc,
+            )
 
             self._model_registry.save_metrics(
                 run_dir=run_dir,

--- a/src/finsight/application/use_cases/train_model.py
+++ b/src/finsight/application/use_cases/train_model.py
@@ -174,7 +174,7 @@ class TrainModel:
                 "test_max_date": test_max_date,
             }
 
-            metadata = build_run_manifest(
+            manifest = build_run_manifest(
                 run_id=run_dir_name,
                 model_id=model_type,
                 feature_columns=feature_columns,
@@ -212,9 +212,9 @@ class TrainModel:
                 run_dir=run_dir,
                 metrics=enriched_metrics,
             )
-            self._model_registry.save_metadata(
+            self._model_registry.save_manifest(
                 run_dir=run_dir,
-                metadata=metadata,
+                manifest=manifest,
             )
             self._model_registry.save_predictions(
                 run_dir=run_dir,

--- a/src/finsight/domain/ports.py
+++ b/src/finsight/domain/ports.py
@@ -69,7 +69,7 @@ class ModelRegistryPort(Protocol):
     def save_metrics(self, *, run_dir: str, metrics: Mapping[str, float | int | str]) -> None:
         raise NotImplementedError
 
-    def save_metadata(self, *, run_dir: str, metadata: Mapping[str, Any]) -> None:
+    def save_manifest(self, *, run_dir: str, manifest: Mapping[str, Any]) -> None:
         raise NotImplementedError
 
     def save_predictions(self, *, run_dir: str, predictions: object) -> None:

--- a/src/finsight/infrastructure/persistence/file_model_registry.py
+++ b/src/finsight/infrastructure/persistence/file_model_registry.py
@@ -37,7 +37,7 @@ class LocalFileModelRegistry(ModelRegistryPort):
         self._write_json(Path(run_dir) / "metrics.json", metrics)
 
     def save_metadata(self, *, run_dir: str, metadata: Mapping[str, Any]) -> None:
-        self._write_json(Path(run_dir) / "metadata.json", metadata)
+        self._write_json(Path(run_dir) / "manifest.json", metadata)
 
     def save_predictions(self, *, run_dir: str, predictions: object) -> None:
         output_path = Path(run_dir) / "predictions.csv"

--- a/src/finsight/infrastructure/persistence/file_model_registry.py
+++ b/src/finsight/infrastructure/persistence/file_model_registry.py
@@ -36,8 +36,8 @@ class LocalFileModelRegistry(ModelRegistryPort):
     def save_metrics(self, *, run_dir: str, metrics: Mapping[str, float | int | str]) -> None:
         self._write_json(Path(run_dir) / "metrics.json", metrics)
 
-    def save_metadata(self, *, run_dir: str, metadata: Mapping[str, Any]) -> None:
-        self._write_json(Path(run_dir) / "manifest.json", metadata)
+    def save_manifest(self, *, run_dir: str, manifest: Mapping[str, Any]) -> None:
+        self._write_json(Path(run_dir) / "manifest.json", manifest)
 
     def save_predictions(self, *, run_dir: str, predictions: object) -> None:
         output_path = Path(run_dir) / "predictions.csv"

--- a/tests/unit/application/contracts/test_run_manifest.py
+++ b/tests/unit/application/contracts/test_run_manifest.py
@@ -130,3 +130,19 @@ def test_build_run_manifest_validates_on_create() -> None:
             artifact_paths=payload["artifact_paths"],
             created_at=payload["created_at"],
         )
+
+
+def test_build_run_manifest_rejects_feature_columns_string() -> None:
+    payload = _valid_manifest()
+    with pytest.raises(TypeError, match="feature_columns"):
+        build_run_manifest(
+            run_id=payload["run_id"],
+            model_id=payload["model_id"],
+            feature_columns="ret_1d",
+            target=payload["target"],
+            split_policy=payload["split_policy"],
+            dates=payload["dates"],
+            params=payload["params"],
+            artifact_paths=payload["artifact_paths"],
+            created_at=payload["created_at"],
+        )

--- a/tests/unit/application/contracts/test_run_manifest.py
+++ b/tests/unit/application/contracts/test_run_manifest.py
@@ -57,6 +57,22 @@ def test_validate_run_manifest_rejects_bad_created_at_format() -> None:
         validate_run_manifest(manifest)
 
 
+def test_validate_run_manifest_rejects_created_at_with_space_separator() -> None:
+    manifest = _valid_manifest()
+    manifest["created_at"] = "2026-03-29 12:00:00Z"
+
+    with pytest.raises(ValueError, match="YYYY-MM-DDTHH:MM:SSZ"):
+        validate_run_manifest(manifest)
+
+
+def test_validate_run_manifest_rejects_created_at_with_fractional_seconds() -> None:
+    manifest = _valid_manifest()
+    manifest["created_at"] = "2026-03-29T12:00:00.123Z"
+
+    with pytest.raises(ValueError, match="YYYY-MM-DDTHH:MM:SSZ"):
+        validate_run_manifest(manifest)
+
+
 def test_validate_run_manifest_rejects_bad_dates_format() -> None:
     manifest = _valid_manifest()
     manifest["dates"] = {**manifest["dates"], "test_max": "03-29-2026"}

--- a/tests/unit/application/contracts/test_run_manifest.py
+++ b/tests/unit/application/contracts/test_run_manifest.py
@@ -1,0 +1,82 @@
+import pytest
+
+from finsight.application.contracts import REQUIRED_MANIFEST_KEYS, build_run_manifest, validate_run_manifest
+
+
+def _valid_manifest() -> dict[str, object]:
+    return {
+        "run_id": "2026-03-29T120000Z__naive_zero",
+        "model_id": "naive_zero",
+        "feature_columns": ["ret_1d", "mom_20d"],
+        "target": "target_ret_1d",
+        "split_policy": {
+            "name": "time_split",
+            "cutoff_date": "2025-06-01",
+            "date_col": "date",
+            "inclusive_test": True,
+        },
+        "dates": {
+            "requested_start": "2024-03-18",
+            "requested_end": "2026-03-17",
+            "train_min": "2024-03-18",
+            "train_max": "2025-05-31",
+            "test_min": "2025-06-01",
+            "test_max": "2026-03-17",
+        },
+        "params": {"tickers": ["AAPL", "JPM"], "interval": "1d", "years": 2, "horizon": "1d"},
+        "artifact_paths": {
+            "run_dir": "artifacts/runs/2026-03-29T120000Z__naive_zero",
+            "metrics": "artifacts/runs/2026-03-29T120000Z__naive_zero/metrics.json",
+            "manifest": "artifacts/runs/2026-03-29T120000Z__naive_zero/manifest.json",
+            "predictions": "artifacts/runs/2026-03-29T120000Z__naive_zero/predictions.csv",
+        },
+        "created_at": "2026-03-29T12:00:00Z",
+    }
+
+
+def test_validate_run_manifest_accepts_valid_payload() -> None:
+    manifest = _valid_manifest()
+    validated = validate_run_manifest(manifest)
+    assert set(REQUIRED_MANIFEST_KEYS) == set(validated.keys())
+
+
+def test_validate_run_manifest_rejects_missing_required_key() -> None:
+    manifest = _valid_manifest()
+    manifest.pop("artifact_paths")
+
+    with pytest.raises(ValueError, match="missing required key"):
+        validate_run_manifest(manifest)
+
+
+def test_validate_run_manifest_rejects_bad_created_at_format() -> None:
+    manifest = _valid_manifest()
+    manifest["created_at"] = "2026-03-29 12:00:00"
+
+    with pytest.raises(TypeError, match="created_at"):
+        validate_run_manifest(manifest)
+
+
+def test_validate_run_manifest_rejects_bad_dates_format() -> None:
+    manifest = _valid_manifest()
+    manifest["dates"] = {**manifest["dates"], "test_max": "03-29-2026"}
+
+    with pytest.raises(ValueError, match="dates.test_max"):
+        validate_run_manifest(manifest)
+
+
+def test_build_run_manifest_validates_on_create() -> None:
+    payload = _valid_manifest()
+    payload["feature_columns"] = ["ret_1d", "ret_1d"]
+
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        build_run_manifest(
+            run_id=payload["run_id"],
+            model_id=payload["model_id"],
+            feature_columns=payload["feature_columns"],
+            target=payload["target"],
+            split_policy=payload["split_policy"],
+            dates=payload["dates"],
+            params=payload["params"],
+            artifact_paths=payload["artifact_paths"],
+            created_at=payload["created_at"],
+        )

--- a/tests/unit/application/contracts/test_run_manifest.py
+++ b/tests/unit/application/contracts/test_run_manifest.py
@@ -64,6 +64,24 @@ def test_validate_run_manifest_rejects_bad_dates_format() -> None:
         validate_run_manifest(manifest)
 
 
+def test_validate_run_manifest_accepts_feature_columns_tuple_and_normalizes_to_list() -> None:
+    manifest = _valid_manifest()
+    manifest["feature_columns"] = ("ret_1d", "mom_20d")
+
+    validated = validate_run_manifest(manifest)
+
+    assert validated["feature_columns"] == ["ret_1d", "mom_20d"]
+    assert isinstance(validated["feature_columns"], list)
+
+
+def test_validate_run_manifest_rejects_feature_columns_string() -> None:
+    manifest = _valid_manifest()
+    manifest["feature_columns"] = "ret_1d"
+
+    with pytest.raises(TypeError, match="feature_columns"):
+        validate_run_manifest(manifest)
+
+
 def test_build_run_manifest_validates_on_create() -> None:
     payload = _valid_manifest()
     payload["feature_columns"] = ["ret_1d", "ret_1d"]

--- a/tests/unit/application/contracts/test_run_manifest.py
+++ b/tests/unit/application/contracts/test_run_manifest.py
@@ -1,4 +1,5 @@
 import pytest
+from types import MappingProxyType
 
 from finsight.application.contracts import REQUIRED_MANIFEST_KEYS, build_run_manifest, validate_run_manifest
 
@@ -80,6 +81,21 @@ def test_validate_run_manifest_rejects_feature_columns_string() -> None:
 
     with pytest.raises(TypeError, match="feature_columns"):
         validate_run_manifest(manifest)
+
+
+def test_validate_run_manifest_normalizes_nested_mappings_to_dict() -> None:
+    manifest = _valid_manifest()
+    manifest["split_policy"] = MappingProxyType(dict(manifest["split_policy"]))
+    manifest["dates"] = MappingProxyType(dict(manifest["dates"]))
+    manifest["params"] = MappingProxyType(dict(manifest["params"]))
+    manifest["artifact_paths"] = MappingProxyType(dict(manifest["artifact_paths"]))
+
+    validated = validate_run_manifest(manifest)
+
+    assert isinstance(validated["split_policy"], dict)
+    assert isinstance(validated["dates"], dict)
+    assert isinstance(validated["params"], dict)
+    assert isinstance(validated["artifact_paths"], dict)
 
 
 def test_build_run_manifest_validates_on_create() -> None:

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -127,27 +127,27 @@ def test_execute_writes_artifacts_and_applies_unique_run_dir_suffix(tmp_path, mo
 
     for model_type, run_dir in (("naive_zero", naive_zero_dir), ("naive_mean", naive_mean_dir)):
         metrics_path = run_dir / "metrics.json"
-        metadata_path = run_dir / "manifest.json"
+        manifest_path = run_dir / "manifest.json"
         predictions_path = run_dir / "predictions.csv"
 
         assert metrics_path.exists()
-        assert metadata_path.exists()
+        assert manifest_path.exists()
         assert predictions_path.exists()
 
         metrics_json = json.loads(metrics_path.read_text(encoding="utf-8"))
-        metadata_json = json.loads(metadata_path.read_text(encoding="utf-8"))
+        manifest_json = json.loads(manifest_path.read_text(encoding="utf-8"))
         predictions_df = pd.read_csv(predictions_path)
 
-        assert set(REQUIRED_MANIFEST_KEYS).issubset(metadata_json)
-        assert metadata_json["model_id"] == model_type
-        assert metadata_json["run_id"] == run_dir.name
-        assert metadata_json["params"]["tickers"] == ["AAPL", "JPM"]
-        assert metadata_json["params"]["interval"] == "1d"
-        assert metadata_json["target"] == "target_ret_1d"
-        assert metadata_json["split_policy"]["name"] == "time_split"
-        assert metadata_json["split_policy"]["cutoff_date"] == "2025-06-01"
-        assert metadata_json["artifact_paths"]["manifest"].endswith("manifest.json")
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", metadata_json["created_at"])
+        assert set(REQUIRED_MANIFEST_KEYS).issubset(manifest_json)
+        assert manifest_json["model_id"] == model_type
+        assert manifest_json["run_id"] == run_dir.name
+        assert manifest_json["params"]["tickers"] == ["AAPL", "JPM"]
+        assert manifest_json["params"]["interval"] == "1d"
+        assert manifest_json["target"] == "target_ret_1d"
+        assert manifest_json["split_policy"]["name"] == "time_split"
+        assert manifest_json["split_policy"]["cutoff_date"] == "2025-06-01"
+        assert manifest_json["artifact_paths"]["manifest"].endswith("manifest.json")
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", manifest_json["created_at"])
         for date_key in (
             "requested_start",
             "requested_end",
@@ -156,7 +156,7 @@ def test_execute_writes_artifacts_and_applies_unique_run_dir_suffix(tmp_path, mo
             "test_min",
             "test_max",
         ):
-            assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", metadata_json["dates"][date_key])
+            assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", manifest_json["dates"][date_key])
 
         assert metrics_json["n_train"] > 0
         assert metrics_json["n_test"] > 0

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import cast
@@ -9,6 +10,7 @@ import pytest
 import finsight.application.use_cases.train_model as train_model_module
 from finsight.application.use_cases.fetch_market_data import FetchMarketData, FetchMarketDataRequest
 from finsight.application.use_cases.train_model import TrainModel, TrainModelRequest
+from finsight.application.contracts import REQUIRED_MANIFEST_KEYS
 from finsight.domain.entities import OHLCVSeries
 from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
 from finsight.domain.value_objects import DateRange, Interval, Ticker
@@ -125,7 +127,7 @@ def test_execute_writes_artifacts_and_applies_unique_run_dir_suffix(tmp_path, mo
 
     for model_type, run_dir in (("naive_zero", naive_zero_dir), ("naive_mean", naive_mean_dir)):
         metrics_path = run_dir / "metrics.json"
-        metadata_path = run_dir / "metadata.json"
+        metadata_path = run_dir / "manifest.json"
         predictions_path = run_dir / "predictions.csv"
 
         assert metrics_path.exists()
@@ -136,10 +138,25 @@ def test_execute_writes_artifacts_and_applies_unique_run_dir_suffix(tmp_path, mo
         metadata_json = json.loads(metadata_path.read_text(encoding="utf-8"))
         predictions_df = pd.read_csv(predictions_path)
 
-        assert metadata_json["model_type"] == model_type
+        assert set(REQUIRED_MANIFEST_KEYS).issubset(metadata_json)
+        assert metadata_json["model_id"] == model_type
         assert metadata_json["run_id"] == run_dir.name
-        assert metadata_json["tickers"] == ["AAPL", "JPM"]
-        assert metadata_json["interval"] == "1d"
+        assert metadata_json["params"]["tickers"] == ["AAPL", "JPM"]
+        assert metadata_json["params"]["interval"] == "1d"
+        assert metadata_json["target"] == "target_ret_1d"
+        assert metadata_json["split_policy"]["name"] == "time_split"
+        assert metadata_json["split_policy"]["cutoff_date"] == "2025-06-01"
+        assert metadata_json["artifact_paths"]["manifest"].endswith("manifest.json")
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", metadata_json["created_at"])
+        for date_key in (
+            "requested_start",
+            "requested_end",
+            "train_min",
+            "train_max",
+            "test_min",
+            "test_max",
+        ):
+            assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", metadata_json["dates"][date_key])
 
         assert metrics_json["n_train"] > 0
         assert metrics_json["n_test"] > 0


### PR DESCRIPTION
This pull request introduces a standardized manifest structure for model training runs, ensuring consistency and validation of metadata across the application. The main changes include the creation of a contract for run manifests, integration of this manifest into the model training workflow, and updates to both the file persistence layer and related tests to support and verify the new manifest format.

**Manifest contract and validation:**
- Added `run_manifest.py` defining `REQUIRED_MANIFEST_KEYS`, `build_run_manifest`, and `validate_run_manifest`, which enforce required fields, types, and formats for run metadata. This includes thorough validation for dates, unique feature columns, and required nested keys.
- Exposed these manifest-related functions and constants in the `contracts` package’s `__init__.py` for easy import elsewhere in the application.

**Integration into training workflow:**
- Updated `TrainModel` use case to construct run metadata using `build_run_manifest`, replacing the previous ad-hoc dictionary with a validated manifest. This ensures that all training runs produce consistent, validated metadata.

**Persistence and file naming:**
- Changed the file where run metadata is saved from `metadata.json` to `manifest.json` in the file-based model registry, aligning with the new manifest terminology and format.

**Testing and validation:**
- Added comprehensive unit tests for the manifest contract, covering acceptance of valid manifests, rejection of missing or malformed fields, and validation on manifest creation.
- Updated model training integration tests to check for the new manifest file, verify required keys, and assert correct structure and value formats (e.g., ISO dates, nested parameters). 