### PR TITLE
Introduce pluggable sklearn model adapters

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -36,8 +36,8 @@ model_defaults:
       supports_prediction: true
     - id: "ridge"
       label: "Ridge Regression"
-      supports_training: false
-      supports_prediction: false
+      supports_training: true
+      supports_prediction: true
   default_model_id: "naive_zero"
   horizon_min: 7
   horizon_max: 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "yfinance",
   "PyYAML",
   "numpy",
-  "joblib"
+  "joblib",
+  "scikit-learn"
 ]
 
 [project.optional-dependencies]
@@ -24,9 +25,6 @@ dev = [
   "pytest",
   "pytest-cov",
   "diff-cover",
-]
-ml = [
-  "scikit-learn"
 ]
 
 [project.scripts]

--- a/src/finsight/application/use_cases/train_model.py
+++ b/src/finsight/application/use_cases/train_model.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from finsight.application.contracts import build_run_manifest
 import finsight.application.dto as application_dto
 from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.domain.entities import ModelEvaluationResult
 from finsight.domain.ports import FeatureStorePort, ModelPort, ModelRegistryPort
 
 TARGET_COLUMN = "target_ret_1d"
@@ -113,17 +114,15 @@ class TrainModel:
             inclusive_test=True,
         )
 
-        model_metrics: dict[str, dict[str, float]] = {}
-        predictions_by_model: dict[str, object] = {}
+        evaluation_by_model: dict[str, ModelEvaluationResult] = {}
         for model_type in model_types:
-            metric_values, predictions = self._model.evaluate(
+            evaluation_result = self._model.evaluate(
                 train_dataset=train_dataset,
                 test_dataset=test_dataset,
                 model_type=model_type,
                 target_column=TARGET_COLUMN,
             )
-            model_metrics[model_type] = dict(metric_values)
-            predictions_by_model[model_type] = predictions
+            evaluation_by_model[model_type] = evaluation_result
 
         train_min_date, train_max_date = self._feature_store.frame_date_range(train_dataset)
         test_min_date, test_max_date = self._feature_store.frame_date_range(test_dataset)
@@ -139,6 +138,7 @@ class TrainModel:
         metrics: dict[str, dict[str, float | int | str]] = {}
 
         for model_type in model_types:
+            evaluation_result = evaluation_by_model[model_type]
             run_id = f"{run_prefix}__{model_type}"
             run_dir = self._model_registry.create_run_dir(
                 artifact_root=request.artifacts_dir,
@@ -148,11 +148,11 @@ class TrainModel:
 
             self._model_registry.save_model(
                 run_dir=run_dir,
-                model=self._model,
+                model=evaluation_result.trained_artifact,
             )
 
             enriched_metrics: dict[str, float | int | str] = {
-                **model_metrics[model_type],
+                **dict(evaluation_result.metrics),
                 "n_train": n_train,
                 "n_test": n_test,
                 "train_min_date": train_min_date,
@@ -185,6 +185,7 @@ class TrainModel:
                     "interval": resolved_interval,
                     "years": int(request.years),
                     "horizon": "1d",
+                    "model_metadata": dict(evaluation_result.model_metadata),
                 },
                 artifact_paths={
                     "run_dir": run_dir,
@@ -205,7 +206,7 @@ class TrainModel:
             )
             self._model_registry.save_predictions(
                 run_dir=run_dir,
-                predictions=predictions_by_model[model_type],
+                predictions=evaluation_result.predictions,
             )
 
             run_dirs[model_type] = run_dir

--- a/src/finsight/bootstrap/container.py
+++ b/src/finsight/bootstrap/container.py
@@ -8,7 +8,7 @@ from finsight.application.use_cases.train_model import TrainModel
 from finsight.config.settings import get_settings
 from finsight.infrastructure.features.feature_store import PandasFeatureStore
 from finsight.infrastructure.market_data.yfinance_provider import YFinanceMarketDataProvider
-from finsight.infrastructure.ml.sklearn.baseline import NaiveBaselineModel
+from finsight.infrastructure.ml.sklearn import LinearSklearnModel, NaiveBaselineModel, SklearnModelRouter
 from finsight.infrastructure.ml.registry import LocalFileModelRegistry
 
 
@@ -33,7 +33,7 @@ def build_container() -> AppContainer:
     )
 
     feature_store = PandasFeatureStore()
-    model = NaiveBaselineModel()
+    model = SklearnModelRouter(adapters=[NaiveBaselineModel(), LinearSklearnModel()])
     model_registry = LocalFileModelRegistry()
     train_model = TrainModel(
         fetch_market_data=fetch_market_data,

--- a/src/finsight/config/settings.py
+++ b/src/finsight/config/settings.py
@@ -39,7 +39,7 @@ class ModelCatalogEntry:
 DEFAULT_MODEL_CATALOG: tuple[ModelCatalogEntry, ...] = (
     ModelCatalogEntry(id="naive_zero", label="Naive (Zero)", supports_training=True, supports_prediction=True),
     ModelCatalogEntry(id="naive_mean", label="Naive (Mean)", supports_training=True, supports_prediction=True),
-    ModelCatalogEntry(id="ridge", label="Ridge Regression", supports_training=False, supports_prediction=False),
+    ModelCatalogEntry(id="ridge", label="Ridge Regression", supports_training=True, supports_prediction=True),
 )
 
 

--- a/src/finsight/domain/entities.py
+++ b/src/finsight/domain/entities.py
@@ -28,3 +28,12 @@ class StockSummary:
     ticker: Ticker
     data: Mapping[str, Any]
 
+
+@dataclass(frozen=True, slots=True)
+class ModelEvaluationResult:
+    metrics: Mapping[str, float]
+    predictions: object
+    trained_artifact: object
+    model_metadata: Mapping[str, Any]
+
+

--- a/src/finsight/domain/ports.py
+++ b/src/finsight/domain/ports.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
 
-from finsight.domain.entities import OHLCVSeries, StockSummary
+from finsight.domain.entities import ModelEvaluationResult, OHLCVSeries, StockSummary
 from finsight.domain.value_objects import DateRange, Interval, Ticker
 
 
@@ -55,7 +55,7 @@ class ModelPort(Protocol):
         model_type: str,
         target_column: str,
         id_columns: Sequence[str] = ("date", "ticker"),
-    ) -> tuple[Mapping[str, float], object]:
+    ) -> ModelEvaluationResult:
         raise NotImplementedError
 
     def supported_model_types(self) -> tuple[str, ...]:

--- a/src/finsight/infrastructure/ml/sklearn/__init__.py
+++ b/src/finsight/infrastructure/ml/sklearn/__init__.py
@@ -1,4 +1,6 @@
 from finsight.infrastructure.ml.sklearn.baseline import NaiveBaselineModel
+from finsight.infrastructure.ml.sklearn.linear import LinearSklearnModel
+from finsight.infrastructure.ml.sklearn.router import SklearnModelRouter
 
-__all__ = ["NaiveBaselineModel"]
+__all__ = ["NaiveBaselineModel", "LinearSklearnModel", "SklearnModelRouter"]
 

--- a/src/finsight/infrastructure/ml/sklearn/baseline.py
+++ b/src/finsight/infrastructure/ml/sklearn/baseline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence
 
 import numpy as np
@@ -10,6 +11,24 @@ from finsight.domain.metrics import forecast_metrics
 from finsight.domain.ports import ModelPort
 
 SUPPORTED_MODEL_TYPES = ("naive_zero", "naive_mean")
+
+
+@dataclass(frozen=True, slots=True)
+class NaiveBaselineArtifact:
+    baseline_value: float
+
+    def predict(self, X: object) -> np.ndarray:
+        n_rows = self._row_count(X)
+        return np.full(n_rows, fill_value=self.baseline_value, dtype=float)
+
+    @staticmethod
+    def _row_count(X: object) -> int:
+        if hasattr(X, "shape") and getattr(X, "shape"):
+            return int(getattr(X, "shape")[0])
+        try:
+            return int(len(X))  # type: ignore[arg-type]
+        except TypeError as exc:  # pragma: no cover - defensive fallback
+            raise TypeError("predict input must be a sized collection or array-like object.") from exc
 
 
 class NaiveBaselineModel(ModelPort):
@@ -56,11 +75,7 @@ class NaiveBaselineModel(ModelPort):
         return ModelEvaluationResult(
             metrics=metrics,
             predictions=predictions.reset_index(drop=True),
-            trained_artifact={
-                "adapter": "NaiveBaselineModel",
-                "model_id": model_type,
-                "baseline_value": baseline_value,
-            },
+            trained_artifact=NaiveBaselineArtifact(baseline_value=baseline_value),
             model_metadata={
                 "adapter": "NaiveBaselineModel",
                 "model_id": model_type,

--- a/src/finsight/infrastructure/ml/sklearn/baseline.py
+++ b/src/finsight/infrastructure/ml/sklearn/baseline.py
@@ -5,6 +5,7 @@ from typing import Sequence
 import numpy as np
 import pandas as pd
 
+from finsight.domain.entities import ModelEvaluationResult
 from finsight.domain.metrics import forecast_metrics
 from finsight.domain.ports import ModelPort
 
@@ -20,7 +21,7 @@ class NaiveBaselineModel(ModelPort):
         model_type: str,
         target_column: str,
         id_columns: Sequence[str] = ("date", "ticker"),
-    ) -> tuple[dict[str, float], pd.DataFrame]:
+    ) -> ModelEvaluationResult:
         train_df = self._require_dataframe(train_dataset, arg_name="train_dataset")
         test_df = self._require_dataframe(test_dataset, arg_name="test_dataset")
 
@@ -40,8 +41,10 @@ class NaiveBaselineModel(ModelPort):
 
         if model_type == "naive_zero":
             y_pred = np.zeros_like(y_test, dtype=float)
+            baseline_value = 0.0
         else:
-            y_pred = np.full_like(y_test, fill_value=float(np.mean(y_train)), dtype=float)
+            baseline_value = float(np.mean(y_train))
+            y_pred = np.full_like(y_test, fill_value=baseline_value, dtype=float)
 
         metrics = forecast_metrics(y_true=y_test.tolist(), y_pred=y_pred.tolist())
 
@@ -50,7 +53,22 @@ class NaiveBaselineModel(ModelPort):
         predictions["y_true"] = y_test
         predictions["y_pred"] = y_pred
 
-        return metrics, predictions.reset_index(drop=True)
+        return ModelEvaluationResult(
+            metrics=metrics,
+            predictions=predictions.reset_index(drop=True),
+            trained_artifact={
+                "adapter": "NaiveBaselineModel",
+                "model_id": model_type,
+                "baseline_value": baseline_value,
+            },
+            model_metadata={
+                "adapter": "NaiveBaselineModel",
+                "model_id": model_type,
+                "baseline_value": baseline_value,
+                "n_train": int(len(train_df)),
+                "n_test": int(len(test_df)),
+            },
+        )
 
     def supported_model_types(self) -> tuple[str, ...]:
         return SUPPORTED_MODEL_TYPES

--- a/src/finsight/infrastructure/ml/sklearn/linear.py
+++ b/src/finsight/infrastructure/ml/sklearn/linear.py
@@ -96,7 +96,12 @@ class LinearSklearnModel(ModelPort):
     ) -> list[str]:
         excluded = {target_column, *id_columns}
         common = [col for col in train_df.columns if col in test_df.columns and col not in excluded]
-        numeric = [col for col in common if pd.api.types.is_numeric_dtype(train_df[col])]
+        numeric = [
+            col
+            for col in common
+            if pd.api.types.is_numeric_dtype(train_df[col])
+            and pd.api.types.is_numeric_dtype(test_df[col])
+        ]
         return numeric
 
     @staticmethod

--- a/src/finsight/infrastructure/ml/sklearn/linear.py
+++ b/src/finsight/infrastructure/ml/sklearn/linear.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+from sklearn.linear_model import Ridge
+
+from finsight.domain.metrics import forecast_metrics
+from finsight.domain.ports import ModelPort
+
+SUPPORTED_MODEL_TYPES = ("ridge",)
+
+
+class LinearSklearnModel(ModelPort):
+    def evaluate(
+        self,
+        *,
+        train_dataset: object,
+        test_dataset: object,
+        model_type: str,
+        target_column: str,
+        id_columns: Sequence[str] = ("date", "ticker"),
+    ) -> tuple[dict[str, float], pd.DataFrame]:
+        train_df = self._require_dataframe(train_dataset, arg_name="train_dataset")
+        test_df = self._require_dataframe(test_dataset, arg_name="test_dataset")
+
+        if model_type not in SUPPORTED_MODEL_TYPES:
+            raise ValueError(
+                f"Unsupported model type '{model_type}'. Supported model types: {SUPPORTED_MODEL_TYPES}."
+            )
+
+        if target_column not in train_df.columns or target_column not in test_df.columns:
+            raise ValueError(f"Both train_df and test_df must contain '{target_column}'.")
+
+        if train_df.empty or test_df.empty:
+            raise ValueError("train_df and test_df must be non-empty for evaluation.")
+
+        feature_columns = self._feature_columns(train_df, test_df, target_column=target_column, id_columns=id_columns)
+        if not feature_columns:
+            raise ValueError("No numeric feature columns available for linear model evaluation.")
+
+        x_train = train_df.loc[:, feature_columns].to_numpy(dtype=float)
+        x_test = test_df.loc[:, feature_columns].to_numpy(dtype=float)
+        y_train = train_df[target_column].to_numpy(dtype=float)
+        y_test = test_df[target_column].to_numpy(dtype=float)
+
+        model = Ridge(alpha=1.0)
+        model.fit(x_train, y_train)
+        y_pred = model.predict(x_test)
+
+        metrics = forecast_metrics(y_true=y_test.tolist(), y_pred=y_pred.tolist())
+
+        pred_cols = [col for col in id_columns if col in test_df.columns]
+        predictions = test_df[pred_cols].copy() if pred_cols else pd.DataFrame(index=test_df.index)
+        predictions["y_true"] = y_test
+        predictions["y_pred"] = y_pred
+
+        return metrics, predictions.reset_index(drop=True)
+
+    def supported_model_types(self) -> tuple[str, ...]:
+        return SUPPORTED_MODEL_TYPES
+
+    @staticmethod
+    def _feature_columns(
+        train_df: pd.DataFrame,
+        test_df: pd.DataFrame,
+        *,
+        target_column: str,
+        id_columns: Sequence[str],
+    ) -> list[str]:
+        excluded = {target_column, *id_columns}
+        common = [col for col in train_df.columns if col in test_df.columns and col not in excluded]
+        numeric = [col for col in common if pd.api.types.is_numeric_dtype(train_df[col])]
+        return numeric
+
+    @staticmethod
+    def _require_dataframe(dataset: object, *, arg_name: str) -> pd.DataFrame:
+        if not isinstance(dataset, pd.DataFrame):
+            raise TypeError(f"{arg_name} must be a pandas DataFrame.")
+        return dataset
+

--- a/src/finsight/infrastructure/ml/sklearn/linear.py
+++ b/src/finsight/infrastructure/ml/sklearn/linear.py
@@ -4,7 +4,10 @@ from typing import Sequence
 
 import pandas as pd
 from sklearn.linear_model import Ridge
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
+from finsight.domain.entities import ModelEvaluationResult
 from finsight.domain.metrics import forecast_metrics
 from finsight.domain.ports import ModelPort
 
@@ -20,7 +23,7 @@ class LinearSklearnModel(ModelPort):
         model_type: str,
         target_column: str,
         id_columns: Sequence[str] = ("date", "ticker"),
-    ) -> tuple[dict[str, float], pd.DataFrame]:
+    ) -> ModelEvaluationResult:
         train_df = self._require_dataframe(train_dataset, arg_name="train_dataset")
         test_df = self._require_dataframe(test_dataset, arg_name="test_dataset")
 
@@ -44,9 +47,15 @@ class LinearSklearnModel(ModelPort):
         y_train = train_df[target_column].to_numpy(dtype=float)
         y_test = test_df[target_column].to_numpy(dtype=float)
 
-        model = Ridge(alpha=1.0)
+        alpha = 100.0
+        model = Pipeline([
+            ("scaler", StandardScaler()),
+            ("ridge", Ridge(alpha=alpha)),
+        ])
         model.fit(x_train, y_train)
         y_pred = model.predict(x_test)
+        ridge_model = model.named_steps["ridge"]
+        coefficient_ranking = self._coefficient_ranking(feature_columns, ridge_model.coef_)
 
         metrics = forecast_metrics(y_true=y_test.tolist(), y_pred=y_pred.tolist())
 
@@ -55,7 +64,24 @@ class LinearSklearnModel(ModelPort):
         predictions["y_true"] = y_test
         predictions["y_pred"] = y_pred
 
-        return metrics, predictions.reset_index(drop=True)
+        return ModelEvaluationResult(
+            metrics=metrics,
+            predictions=predictions.reset_index(drop=True),
+            trained_artifact=model,
+            model_metadata={
+                "adapter": "LinearSklearnModel",
+                "model_id": model_type,
+                "estimator": model.__class__.__name__,
+                "base_estimator": ridge_model.__class__.__name__,
+                "feature_columns": feature_columns,
+                "n_features": len(feature_columns),
+                "hyperparams": {"alpha": alpha},
+                "preprocessing": {"scaler": "StandardScaler"},
+                "coefficient_space": "standardized",
+                "coefficients": {item["feature"]: item["coefficient"] for item in coefficient_ranking},
+                "coefficient_ranking": coefficient_ranking,
+            },
+        )
 
     def supported_model_types(self) -> tuple[str, ...]:
         return SUPPORTED_MODEL_TYPES
@@ -78,4 +104,17 @@ class LinearSklearnModel(ModelPort):
         if not isinstance(dataset, pd.DataFrame):
             raise TypeError(f"{arg_name} must be a pandas DataFrame.")
         return dataset
+
+    @staticmethod
+    def _coefficient_ranking(feature_columns: list[str], coefficients: object) -> list[dict[str, float | str]]:
+        coef_series = pd.Series(coefficients, index=feature_columns, dtype=float)
+        ranking = coef_series.abs().sort_values(ascending=False)
+        return [
+            {
+                "feature": str(feature),
+                "coefficient": float(coef_series.loc[feature]),
+                "abs_coefficient": float(abs_value),
+            }
+            for feature, abs_value in ranking.items()
+        ]
 

--- a/src/finsight/infrastructure/ml/sklearn/router.py
+++ b/src/finsight/infrastructure/ml/sklearn/router.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from finsight.domain.entities import ModelEvaluationResult
 from finsight.domain.ports import ModelPort
 
 
@@ -36,7 +37,7 @@ class SklearnModelRouter(ModelPort):
         model_type: str,
         target_column: str,
         id_columns: Sequence[str] = ("date", "ticker"),
-    ) -> tuple[dict[str, float], object]:
+    ) -> ModelEvaluationResult:
         adapter = self._adapter_by_model_id.get(model_type)
         if adapter is None:
             raise ValueError(

--- a/src/finsight/infrastructure/ml/sklearn/router.py
+++ b/src/finsight/infrastructure/ml/sklearn/router.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from finsight.domain.ports import ModelPort
+
+
+class SklearnModelRouter(ModelPort):
+    """Routes model evaluation requests to the adapter that owns a model id."""
+
+    def __init__(self, adapters: Sequence[ModelPort]) -> None:
+        if not adapters:
+            raise ValueError("SklearnModelRouter requires at least one model adapter.")
+
+        adapter_map: dict[str, ModelPort] = {}
+        ordered_model_ids: list[str] = []
+
+        for adapter in adapters:
+            for model_id in tuple(adapter.supported_model_types()):
+                if model_id in adapter_map:
+                    raise ValueError(f"Duplicate model id '{model_id}' detected across model adapters.")
+                adapter_map[model_id] = adapter
+                ordered_model_ids.append(model_id)
+
+        if not ordered_model_ids:
+            raise ValueError("SklearnModelRouter adapters must expose at least one supported model id.")
+
+        self._adapter_by_model_id = adapter_map
+        self._supported_model_ids = tuple(ordered_model_ids)
+
+    def evaluate(
+        self,
+        *,
+        train_dataset: object,
+        test_dataset: object,
+        model_type: str,
+        target_column: str,
+        id_columns: Sequence[str] = ("date", "ticker"),
+    ) -> tuple[dict[str, float], object]:
+        adapter = self._adapter_by_model_id.get(model_type)
+        if adapter is None:
+            raise ValueError(
+                f"Unsupported model type '{model_type}'. Supported model types: {self._supported_model_ids}."
+            )
+
+        return adapter.evaluate(
+            train_dataset=train_dataset,
+            test_dataset=test_dataset,
+            model_type=model_type,
+            target_column=target_column,
+            id_columns=id_columns,
+        )
+
+    def supported_model_types(self) -> tuple[str, ...]:
+        return self._supported_model_ids
+

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -17,7 +17,7 @@ from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
 from finsight.domain.value_objects import DateRange, Interval, Ticker
 from finsight.infrastructure.features import PandasFeatureStore
 from finsight.infrastructure.ml.registry import LocalFileModelRegistry
-from finsight.infrastructure.ml.sklearn import NaiveBaselineModel
+from finsight.infrastructure.ml.sklearn import LinearSklearnModel, NaiveBaselineModel, SklearnModelRouter
 
 
 class _StubFetchMarketData:
@@ -255,6 +255,33 @@ def test_execute_rejects_non_positive_years(tmp_path) -> None:
         )
 
     assert stub.calls == []
+
+
+def test_execute_supports_ridge_via_router(tmp_path) -> None:
+    tickers = ("AAPL",)
+    stub = _StubFetchMarketData({ticker: _make_ohlcv_series(ticker) for ticker in tickers})
+    train_model = TrainModel(
+        fetch_market_data=cast(FetchMarketData, cast(object, stub)),
+        feature_store=PandasFeatureStore(),
+        model=SklearnModelRouter(adapters=[NaiveBaselineModel(), LinearSklearnModel()]),
+        model_registry=LocalFileModelRegistry(),
+        training_tickers=tickers,
+        supported_model_types=("ridge",),
+    )
+
+    response = train_model.execute(
+        TrainModelRequest(
+            cutoff_date="2025-06-01",
+            years=2,
+            end="2026-03-17",
+            model_types=["ridge"],
+            artifacts_dir=str(tmp_path / "runs"),
+        )
+    )
+
+    assert "ridge" in response.run_dirs
+    assert set(SUPPORTED_METRIC_NAMES).issubset(response.metrics["ridge"])
+    assert stub.calls != []
 
 
 

--- a/tests/unit/application/use_cases/test_train_model_execute.py
+++ b/tests/unit/application/use_cases/test_train_model_execute.py
@@ -1,6 +1,7 @@
 import json
 import re
 from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 
@@ -282,6 +283,26 @@ def test_execute_supports_ridge_via_router(tmp_path) -> None:
     assert "ridge" in response.run_dirs
     assert set(SUPPORTED_METRIC_NAMES).issubset(response.metrics["ridge"])
     assert stub.calls != []
+
+    loaded_model = LocalFileModelRegistry().load_model(
+        artifact_root=str(tmp_path / "runs"),
+        run_id=Path(response.run_dirs["ridge"]).name,
+    )
+    assert loaded_model.__class__.__name__ == "Pipeline"
+    assert "ridge" in loaded_model.named_steps
+    assert "scaler" in loaded_model.named_steps
+
+    manifest_path = Path(response.run_dirs["ridge"]) / "manifest.json"
+    manifest_json = json.loads(manifest_path.read_text(encoding="utf-8"))
+    model_metadata = manifest_json["params"]["model_metadata"]
+    assert model_metadata["model_id"] == "ridge"
+    assert model_metadata["estimator"] == "Pipeline"
+    assert model_metadata["base_estimator"] == "Ridge"
+    assert model_metadata["preprocessing"]["scaler"] == "StandardScaler"
+    assert model_metadata["coefficient_space"] == "standardized"
+    assert isinstance(model_metadata["coefficients"], dict)
+    assert isinstance(model_metadata["coefficient_ranking"], list)
+    assert len(model_metadata["coefficient_ranking"]) == len(model_metadata["feature_columns"])
 
 
 

--- a/tests/unit/application/use_cases/test_train_model_naive.py
+++ b/tests/unit/application/use_cases/test_train_model_naive.py
@@ -11,6 +11,7 @@ from finsight.application.use_cases.train_model import (
 from finsight.domain.metrics import SUPPORTED_METRIC_NAMES, METRIC_DIRECTION_ACCURACY
 from finsight.infrastructure.features import TimeSplitPolicy
 from finsight.infrastructure.ml.sklearn import NaiveBaselineModel
+from finsight.infrastructure.ml.sklearn.baseline import NaiveBaselineArtifact
 
 
 def _synthetic_feature_frame() -> pd.DataFrame:
@@ -67,9 +68,13 @@ def test_naive_baseline_model_predictions_and_metrics() -> None:
     )
 
     assert np.allclose(zero_result.predictions["y_pred"].to_numpy(), 0.0)
+    assert isinstance(zero_result.trained_artifact, NaiveBaselineArtifact)
+    assert np.allclose(zero_result.trained_artifact.predict(test_df), 0.0)
 
     expected_mean = float(train_df["target_ret_1d"].mean())
     assert np.allclose(mean_result.predictions["y_pred"].to_numpy(), expected_mean)
+    assert isinstance(mean_result.trained_artifact, NaiveBaselineArtifact)
+    assert np.allclose(mean_result.trained_artifact.predict(test_df), expected_mean)
 
     for result in (zero_result, mean_result):
         metrics = result.metrics

--- a/tests/unit/application/use_cases/test_train_model_naive.py
+++ b/tests/unit/application/use_cases/test_train_model_naive.py
@@ -53,25 +53,27 @@ def test_naive_baseline_model_predictions_and_metrics() -> None:
     assert test_df["date"].min().date().isoformat() == "2024-01-04"
 
     model = NaiveBaselineModel()
-    zero_metrics, zero_predictions = model.evaluate(
+    zero_result = model.evaluate(
         train_dataset=train_df,
         test_dataset=test_df,
         model_type="naive_zero",
         target_column="target_ret_1d",
     )
-    mean_metrics, mean_predictions = model.evaluate(
+    mean_result = model.evaluate(
         train_dataset=train_df,
         test_dataset=test_df,
         model_type="naive_mean",
         target_column="target_ret_1d",
     )
 
-    assert np.allclose(zero_predictions["y_pred"].to_numpy(), 0.0)
+    assert np.allclose(zero_result.predictions["y_pred"].to_numpy(), 0.0)
 
     expected_mean = float(train_df["target_ret_1d"].mean())
-    assert np.allclose(mean_predictions["y_pred"].to_numpy(), expected_mean)
+    assert np.allclose(mean_result.predictions["y_pred"].to_numpy(), expected_mean)
 
-    for metrics, predictions in ((zero_metrics, zero_predictions), (mean_metrics, mean_predictions)):
+    for result in (zero_result, mean_result):
+        metrics = result.metrics
+        predictions = result.predictions
         assert set(SUPPORTED_METRIC_NAMES).issubset(metrics.keys())
         assert 0.0 <= metrics[METRIC_DIRECTION_ACCURACY] <= 1.0
         assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]

--- a/tests/unit/infrastructure/ml/sklearn/test_linear.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_linear.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, SUPPORTED_METRIC_NAMES
+from finsight.infrastructure.ml.sklearn.linear import LinearSklearnModel
+
+
+def _synthetic_linear_frames() -> tuple[pd.DataFrame, pd.DataFrame]:
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]),
+            "ticker": ["AAA", "AAA", "AAA", "AAA"],
+            "ret_1d": [0.1, 0.2, 0.3, 0.4],
+            "mom_20d": [1.0, 2.0, 3.0, 4.0],
+            "target_ret_1d": [0.2, 0.4, 0.6, 0.8],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-05", "2024-01-06"]),
+            "ticker": ["AAA", "AAA"],
+            "ret_1d": [0.5, 0.6],
+            "mom_20d": [5.0, 6.0],
+            "target_ret_1d": [1.0, 1.2],
+        }
+    )
+    return train_df, test_df
+
+
+def test_linear_sklearn_model_ridge_smoke_predicts_and_reports_metrics() -> None:
+    model = LinearSklearnModel()
+    train_df, test_df = _synthetic_linear_frames()
+
+    metrics, predictions = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="ridge",
+        target_column="target_ret_1d",
+    )
+
+    assert set(SUPPORTED_METRIC_NAMES).issubset(metrics)
+    assert 0.0 <= metrics[METRIC_DIRECTION_ACCURACY] <= 1.0
+    assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
+    assert len(predictions) == len(test_df)
+    assert np.isfinite(predictions["y_pred"]).all()
+
+
+def test_linear_sklearn_model_rejects_unsupported_model_type() -> None:
+    model = LinearSklearnModel()
+    train_df, test_df = _synthetic_linear_frames()
+
+    with pytest.raises(ValueError, match="Unsupported model type"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="lasso",
+            target_column="target_ret_1d",
+        )
+
+
+def test_linear_sklearn_model_rejects_missing_numeric_features() -> None:
+    model = LinearSklearnModel()
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "ticker": ["AAA", "AAA"],
+            "target_ret_1d": [0.1, 0.2],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03"]),
+            "ticker": ["AAA"],
+            "target_ret_1d": [0.3],
+        }
+    )
+
+    with pytest.raises(ValueError, match="No numeric feature columns"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="ridge",
+            target_column="target_ret_1d",
+        )
+
+
+def test_linear_sklearn_model_reports_supported_model_types() -> None:
+    assert LinearSklearnModel().supported_model_types() == ("ridge",)
+

--- a/tests/unit/infrastructure/ml/sklearn/test_linear.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_linear.py
@@ -32,18 +32,32 @@ def test_linear_sklearn_model_ridge_smoke_predicts_and_reports_metrics() -> None
     model = LinearSklearnModel()
     train_df, test_df = _synthetic_linear_frames()
 
-    metrics, predictions = model.evaluate(
+    result = model.evaluate(
         train_dataset=train_df,
         test_dataset=test_df,
         model_type="ridge",
         target_column="target_ret_1d",
     )
 
+    metrics = result.metrics
+    predictions = result.predictions
     assert set(SUPPORTED_METRIC_NAMES).issubset(metrics)
     assert 0.0 <= metrics[METRIC_DIRECTION_ACCURACY] <= 1.0
     assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
     assert len(predictions) == len(test_df)
     assert np.isfinite(predictions["y_pred"]).all()
+    assert result.trained_artifact.__class__.__name__ == "Pipeline"
+    assert tuple(result.trained_artifact.named_steps.keys()) == ("scaler", "ridge")
+    assert result.model_metadata["model_id"] == "ridge"
+    assert result.model_metadata["base_estimator"] == "Ridge"
+    assert result.model_metadata["preprocessing"]["scaler"] == "StandardScaler"
+    assert result.model_metadata["coefficient_space"] == "standardized"
+    assert "coefficients" in result.model_metadata
+    assert "coefficient_ranking" in result.model_metadata
+    ranking = result.model_metadata["coefficient_ranking"]
+    assert isinstance(ranking, list)
+    assert len(ranking) == len(result.model_metadata["feature_columns"])
+    assert ranking[0]["abs_coefficient"] >= ranking[-1]["abs_coefficient"]
 
 
 def test_linear_sklearn_model_rejects_unsupported_model_type() -> None:

--- a/tests/unit/infrastructure/ml/sklearn/test_router.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_router.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import pytest
+
+from finsight.infrastructure.ml.sklearn import LinearSklearnModel, NaiveBaselineModel, SklearnModelRouter
+
+
+def _synthetic_train_test() -> tuple[pd.DataFrame, pd.DataFrame]:
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+            "ticker": ["AAA", "AAA", "AAA"],
+            "target_ret_1d": [0.1, -0.1, 0.2],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-04", "2024-01-05"]),
+            "ticker": ["AAA", "AAA"],
+            "target_ret_1d": [0.05, -0.02],
+        }
+    )
+    return train_df, test_df
+
+
+def test_router_reports_supported_model_types_from_adapters() -> None:
+    router = SklearnModelRouter(adapters=[NaiveBaselineModel()])
+
+    assert router.supported_model_types() == ("naive_zero", "naive_mean")
+
+
+def test_router_reports_supported_model_types_from_multiple_adapters() -> None:
+    router = SklearnModelRouter(adapters=[NaiveBaselineModel(), LinearSklearnModel()])
+
+    assert router.supported_model_types() == ("naive_zero", "naive_mean", "ridge")
+
+
+def test_router_delegates_to_matching_adapter() -> None:
+    router = SklearnModelRouter(adapters=[NaiveBaselineModel()])
+    train_df, test_df = _synthetic_train_test()
+
+    metrics, predictions = router.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="naive_zero",
+        target_column="target_ret_1d",
+    )
+
+    assert "mae" in metrics
+    assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
+    assert len(predictions) == len(test_df)
+
+
+def test_router_rejects_unknown_model_type() -> None:
+    router = SklearnModelRouter(adapters=[NaiveBaselineModel()])
+    train_df, test_df = _synthetic_train_test()
+
+    with pytest.raises(ValueError, match="Unsupported model type"):
+        router.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="ridge",
+            target_column="target_ret_1d",
+        )
+
+
+def test_router_rejects_duplicate_model_ids_across_adapters() -> None:
+    class _DuplicateNaiveAdapter(NaiveBaselineModel):
+        def supported_model_types(self) -> tuple[str, ...]:
+            return ("naive_zero",)
+
+    with pytest.raises(ValueError, match="Duplicate model id"):
+        SklearnModelRouter(adapters=[NaiveBaselineModel(), _DuplicateNaiveAdapter()])
+
+

--- a/tests/unit/infrastructure/ml/sklearn/test_router.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_router.py
@@ -38,13 +38,15 @@ def test_router_delegates_to_matching_adapter() -> None:
     router = SklearnModelRouter(adapters=[NaiveBaselineModel()])
     train_df, test_df = _synthetic_train_test()
 
-    metrics, predictions = router.evaluate(
+    result = router.evaluate(
         train_dataset=train_df,
         test_dataset=test_df,
         model_type="naive_zero",
         target_column="target_ret_1d",
     )
 
+    metrics = result.metrics
+    predictions = result.predictions
     assert "mae" in metrics
     assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
     assert len(predictions) == len(test_df)

--- a/tests/unit/infrastructure/ml/test_registry.py
+++ b/tests/unit/infrastructure/ml/test_registry.py
@@ -6,7 +6,7 @@ import pytest
 from finsight.application.contracts import build_run_manifest
 from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
 from finsight.infrastructure.ml.registry import LocalFileModelRegistry
-from finsight.infrastructure.ml.sklearn import NaiveBaselineModel
+from finsight.infrastructure.ml.sklearn.baseline import NaiveBaselineArtifact
 
 
 def test_local_file_model_registry_round_trip_loads_model_and_metadata(tmp_path: Path) -> None:
@@ -16,7 +16,7 @@ def test_local_file_model_registry_round_trip_loads_model_and_metadata(tmp_path:
 
     run_dir = Path(registry.create_run_dir(artifact_root=str(artifact_root), run_id=run_id))
 
-    model = NaiveBaselineModel()
+    model = NaiveBaselineArtifact(baseline_value=0.0)
     metrics = {
         METRIC_MAE: 0.1,
         METRIC_RMSE: 0.2,
@@ -71,14 +71,15 @@ def test_local_file_model_registry_round_trip_loads_model_and_metadata(tmp_path:
     loaded_manifest = registry.load_manifest(artifact_root=str(artifact_root), run_id=run_dir.name)
     loaded_bundle = registry.load_run_artifacts(artifact_root=str(artifact_root), run_id=run_dir.name)
 
-    assert isinstance(loaded_model, NaiveBaselineModel)
+    assert isinstance(loaded_model, NaiveBaselineArtifact)
     assert loaded_metrics[METRIC_MAE] == metrics[METRIC_MAE]
     assert loaded_metrics[METRIC_DIRECTION_ACCURACY] == metrics[METRIC_DIRECTION_ACCURACY]
     assert loaded_manifest["run_id"] == run_dir.name
     assert loaded_manifest["model_id"] == "naive_zero"
     assert loaded_bundle.run_id == run_dir.name
     assert loaded_bundle.run_dir == str(run_dir)
-    assert isinstance(loaded_bundle.model, NaiveBaselineModel)
+    assert isinstance(loaded_bundle.model, NaiveBaselineArtifact)
+    assert loaded_bundle.model.predict(pd.DataFrame([{}, {}])).tolist() == [0.0, 0.0]
     assert loaded_bundle.metrics[METRIC_RMSE] == metrics[METRIC_RMSE]
     assert loaded_bundle.manifest["artifact_paths"]["manifest"].endswith("manifest.json")
     assert Path(loaded_bundle.model_path).exists()


### PR DESCRIPTION
This pull request introduces support for linear regression models (specifically Ridge Regression) to the machine learning pipeline, refactors the model evaluation interface to return a standardized result object, and improves model routing and configuration. The changes also update dependencies and expand test coverage to accommodate the new model and interface. Below are the most important changes grouped by theme:

**Machine Learning Model Support and Routing:**

* Added `LinearSklearnModel` implementing Ridge Regression with standardized preprocessing, metrics, and coefficient reporting.
* Introduced `SklearnModelRouter` to route model evaluation requests to the appropriate adapter based on model ID, supporting both baseline and linear models.

**Model Evaluation Interface Refactor:**

* Introduced `ModelEvaluationResult` dataclass to standardize outputs from model evaluation, including metrics, predictions, trained artifact, and metadata. All model adapters and the `ModelPort` interface now use this result type. 

**Configuration and Dependency Updates:**

* Enabled training and prediction for the "ridge" model in both the YAML configuration and the Python model catalog. 
* Added `scikit-learn` to the main dependencies in `pyproject.toml` and removed it from optional ML dependencies. 

**Testing and Infrastructure:**

* Updated test imports and infrastructure to support the new model adapters and routing. 

These changes collectively enable more flexible and extensible model evaluation, support new model types, and improve maintainability of the ML pipeline.