### PR TITLE
Chore/issues/20 add model comparison use case

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -52,6 +52,7 @@ Orchestrates domain objects and ports to fulfil business use cases.
 |---|---|
 | `use_cases/train_model.py` | `TrainModel` — builds features, evaluates models, writes run manifests |
 | `use_cases/fetch_market_data.py` | `FetchMarketData` — fetches and summarises OHLCV data |
+| `use_cases/compare_models.py` | `CompareModels` — ranks model runs into a deterministic leaderboard |
 | `dto.py` | All request/response data transfer objects (see [DTO conventions](../conventions/naming-and-contracts.md)) |
 | `contracts/run_manifest.py` | `build_run_manifest`, `validate_run_manifest` — structured training-run records |
 
@@ -102,7 +103,7 @@ Thin presentation layer. Converts use case results into Streamlit widgets.
 
 ### `cli/`
 
-CLI entry point. Parses arguments and delegates to `TrainModel` via the container.
+CLI entry point. Parses arguments and delegates to `TrainModel` and `CompareModels` via the container.
 
 ---
 
@@ -138,6 +139,17 @@ CLI / Streamlit view
        ├─ build_run_manifest + validate_run_manifest
        ├─ ModelRegistryPort.save_manifest               (local filesystem)
        └─ returns TrainModelResult
+```
+
+### Comparing trained models
+
+```
+CLI / Streamlit view
+  └─ CompareModels.execute(CompareModelsRequest)
+       ├─ ModelRegistryPort.latest_run_id              (locates latest run for each model)
+       ├─ ModelRegistryPort.load_run_artifacts          (loads metrics and manifest data)
+       ├─ deterministic metric ranking + tie-breaks
+       └─ returns CompareModelsResult                   (table-ready leaderboard rows)
 ```
 
 ### Fetching market data

--- a/src/finsight/adapters/web_streamlit/views/compare.py
+++ b/src/finsight/adapters/web_streamlit/views/compare.py
@@ -1,5 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pandas as pd
 import streamlit as st
 
+from finsight.application.dto import CompareModelsRequest, CompareModelsResult
+from finsight.bootstrap.container import build_container
+from finsight.config.settings import get_settings
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+
+
+_SETTINGS = get_settings()
+_METRIC_LABELS = {
+    METRIC_MAE: "Mean Absolute Error (lower is better)",
+    METRIC_RMSE: "Root Mean Squared Error (lower is better)",
+    METRIC_DIRECTION_ACCURACY: "Direction Accuracy (higher is better)",
+}
+
+
+@st.cache_resource(ttl=_SETTINGS.cache.resource_ttl_seconds)
+def _compare_models_uc():
+    return build_container().compare_models
+
+
+def _build_comparison_frame(result: CompareModelsResult, *, label_lookup: Mapping[str, str]) -> pd.DataFrame:
+    rows: list[dict[str, object]] = []
+    for row in result.rows:
+        record: dict[str, object] = {
+            "rank": row.rank,
+            "model": label_lookup.get(row.model_id, row.model_id),
+            "model_id": row.model_id,
+            "run_id": row.run_id,
+        }
+        record.update(row.metrics)
+        rows.append(record)
+
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        return frame
+
+    base_columns = ["rank", "model", "model_id", "run_id"]
+    metric_columns = [column for column in result.rank_by if column in frame.columns]
+    remaining_columns = [
+        column for column in frame.columns if column not in base_columns and column not in metric_columns
+    ]
+    return frame[base_columns + metric_columns + sorted(remaining_columns)]
+
+
 def render():
-    st.title("Compare Models - Coming Soon!")
-    st.write("This page is under construction. Stay tuned for updates as we work to bring you this feature!")
+    st.title("Compare Models")
+    st.markdown(
+        "Build a deterministic leaderboard from the latest saved model runs. "
+        "Ranking follows the selected metric order, then model ID, then run ID.")
+
+    model_defaults = _SETTINGS.model_defaults
+    model_ids = list(model_defaults.training_model_ids())
+    id_to_label = model_defaults.id_to_label()
+
+    if not model_ids:
+        st.warning("No training-enabled models are configured.")
+        return
+
+    default_rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY]
+
+    with st.form("compare_models_form"):
+        selected_model_ids = st.multiselect(
+            "Models to compare",
+            model_ids,
+            default=model_ids,
+            format_func=lambda model_id: id_to_label.get(model_id, model_id),
+        )
+        selected_rank_by = st.multiselect(
+            "Ranking metrics",
+            default_rank_by,
+            default=default_rank_by,
+            format_func=lambda metric_name: _METRIC_LABELS.get(metric_name, metric_name),
+        )
+        submit = st.form_submit_button("Build leaderboard")
+
+    if not submit:
+        st.info("Choose models and ranking metrics, then build the leaderboard.")
+        return
+
+    if not selected_model_ids:
+        st.warning("Select at least one model to compare.")
+        return
+
+    if not selected_rank_by:
+        st.warning("Select at least one ranking metric.")
+        return
+
+    try:
+        result = _compare_models_uc().execute(
+            CompareModelsRequest(
+                model_ids=list(selected_model_ids),
+                rank_by=list(selected_rank_by),
+            )
+        )
+    except FileNotFoundError as error:
+        st.error(f"No trained run artifacts were found: {error}")
+        return
+    except (ValueError, TypeError) as error:
+        st.error(f"Unable to build leaderboard: {error}")
+        return
+    except Exception as error:  # pragma: no cover - defensive fallback for UI resilience
+        st.error(f"Leaderboard generation failed unexpectedly: {error}")
+        return
+
+    frame = _build_comparison_frame(result, label_lookup=id_to_label)
+    if frame.empty:
+        st.warning("No comparison rows were returned.")
+        return
+
+    st.subheader("Leaderboard")
+    st.dataframe(frame, use_container_width=True, hide_index=True)
+
+    st.caption(
+        "Ranking priority: "
+        + " → ".join(_METRIC_LABELS.get(metric_name, metric_name) for metric_name in result.rank_by)
+        + "."
+    )

--- a/src/finsight/adapters/web_streamlit/views/compare.py
+++ b/src/finsight/adapters/web_streamlit/views/compare.py
@@ -53,6 +53,10 @@ def render():
     st.markdown(
         "Build a deterministic leaderboard from the latest saved model runs. "
         "Ranking follows the selected metric order, then model ID, then run ID.")
+    st.info(
+        "Metric direction defaults: MAE/RMSE are ranked lower-is-better, while Direction Accuracy is ranked higher-is-better. "
+        "If you reorder metrics, the first metric has the highest priority."
+    )
 
     model_defaults = _SETTINGS.model_defaults
     model_ids = list(model_defaults.training_model_ids())

--- a/src/finsight/application/dto.py
+++ b/src/finsight/application/dto.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from finsight.domain.entities import OHLCVSeries, StockSummary
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
 
 MetricValue = float | int | str
 SerializableScalar = str | int | float | bool | None
@@ -307,6 +308,138 @@ class TrainModelResult:
 
 
 @dataclass(frozen=True, slots=True)
+class ModelComparisonRow:
+    rank: int
+    model_id: str
+    run_id: str
+    metrics: dict[str, MetricValue]
+    sort_key: tuple[Any, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rank": self.rank,
+            "model_id": self.model_id,
+            "run_id": self.run_id,
+            "metrics": dict(self.metrics),
+            "sort_key": list(self.sort_key),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> ModelComparisonRow:
+        metrics_raw = payload.get("metrics", {})
+        metrics: dict[str, MetricValue] = {}
+        if isinstance(metrics_raw, Mapping):
+            metrics = {str(key): value for key, value in metrics_raw.items()}
+
+        sort_key_raw = payload.get("sort_key", ())
+        sort_key: tuple[Any, ...]
+        if isinstance(sort_key_raw, (list, tuple)):
+            sort_key = tuple(sort_key_raw)
+        else:
+            sort_key = ()
+
+        return cls(
+            rank=_safe_int(payload.get("rank", 0), default=0),
+            model_id=_safe_str(payload.get("model_id", "")).strip(),
+            run_id=_safe_str(payload.get("run_id", "")).strip(),
+            metrics=metrics,
+            sort_key=sort_key,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CompareModelsRequest:
+    model_ids: list[str]
+    artifacts_dir: str = "artifacts/runs"
+    rank_by: list[str] = field(default_factory=lambda: [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY])
+    metric_directions: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_ids": list(self.model_ids),
+            "artifacts_dir": self.artifacts_dir,
+            "rank_by": list(self.rank_by),
+            "metric_directions": dict(self.metric_directions),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> CompareModelsRequest:
+        raw_model_ids = payload.get("model_ids", [])
+        raw_rank_by = payload.get("rank_by")
+        raw_metric_directions = payload.get("metric_directions", {})
+
+        model_ids = _string_list(raw_model_ids, default=[])
+        if isinstance(raw_rank_by, (list, tuple)):
+            rank_by = [str(item) for item in raw_rank_by]
+        else:
+            rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY]
+
+        metric_directions: dict[str, str] = {}
+        if isinstance(raw_metric_directions, Mapping):
+            metric_directions = {
+                str(key): str(value).strip().lower()
+                for key, value in raw_metric_directions.items()
+                if str(value).strip()
+            }
+
+        raw_artifacts_dir = payload.get("artifacts_dir")
+        if raw_artifacts_dir is None:
+            artifacts_dir = "artifacts/runs"
+        elif isinstance(raw_artifacts_dir, str):
+            artifacts_dir_candidate = raw_artifacts_dir.strip()
+            artifacts_dir = artifacts_dir_candidate or "artifacts/runs"
+        else:
+            artifacts_dir = str(raw_artifacts_dir)
+
+        return cls(
+            model_ids=model_ids,
+            artifacts_dir=artifacts_dir,
+            rank_by=rank_by,
+            metric_directions=metric_directions,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CompareModelsResult:
+    rows: list[ModelComparisonRow]
+    rank_by: list[str]
+    metric_directions: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rows": [row.to_dict() for row in self.rows],
+            "rank_by": list(self.rank_by),
+            "metric_directions": dict(self.metric_directions),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> CompareModelsResult:
+        rows_raw = payload.get("rows", [])
+        rows: list[ModelComparisonRow] = []
+        if isinstance(rows_raw, list):
+            for row in rows_raw:
+                if isinstance(row, Mapping):
+                    rows.append(ModelComparisonRow.from_dict(row))
+
+        raw_rank_by = payload.get("rank_by", [])
+        if isinstance(raw_rank_by, (list, tuple)):
+            rank_by = [str(item) for item in raw_rank_by]
+        else:
+            rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY]
+
+        raw_metric_directions = payload.get("metric_directions", {})
+        metric_directions: dict[str, str] = {}
+        if isinstance(raw_metric_directions, Mapping):
+            metric_directions = {
+                str(key): str(value).strip().lower()
+                for key, value in raw_metric_directions.items()
+                if str(value).strip()
+            }
+
+        return cls(rows=rows, rank_by=rank_by, metric_directions=metric_directions)
+
+
+@dataclass(frozen=True, slots=True)
 class ModelRunArtifacts:
     run_id: str
     run_dir: str
@@ -436,6 +569,8 @@ class ForecastRequest:
 
 
 __all__ = [
+    "CompareModelsRequest",
+    "CompareModelsResult",
     "BacktestResult",
     "DatasetSpec",
     "FeatureSpec",
@@ -444,6 +579,7 @@ __all__ = [
     "ForecastRequest",
     "ForecastResult",
     "MetricValue",
+    "ModelComparisonRow",
     "ModelRunArtifacts",
     "TrainModelRequest",
     "TrainModelResult",

--- a/src/finsight/application/use_cases/compare_models.py
+++ b/src/finsight/application/use_cases/compare_models.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import math
+from typing import Any, Mapping, Sequence
+
+import finsight.application.dto as application_dto
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.ports import ModelRegistryPort
+
+
+_DEFAULT_DIRECTION_BY_METRIC = {
+    METRIC_MAE: "asc",
+    METRIC_RMSE: "asc",
+    METRIC_DIRECTION_ACCURACY: "desc",
+}
+
+
+def _require_non_empty_text(value: object, *, field_name: str) -> str:
+    if value is None:
+        raise ValueError(f"{field_name} must be a non-empty string.")
+
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field_name} must be a non-empty string.")
+    return normalized
+
+
+def _normalize_model_ids(model_ids: Sequence[str]) -> list[str]:
+    normalized = [_require_non_empty_text(model_id, field_name="model_ids item") for model_id in model_ids]
+    if not normalized:
+        raise ValueError("model_ids must contain at least one model id.")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("model_ids must be unique.")
+    return normalized
+
+
+def _normalize_rank_by(rank_by: Sequence[str]) -> list[str]:
+    normalized = [_require_non_empty_text(metric_name, field_name="rank_by item") for metric_name in rank_by]
+    if not normalized:
+        raise ValueError("rank_by must contain at least one metric name.")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("rank_by must not contain duplicate metric names.")
+    return normalized
+
+
+def _normalize_metric_directions(metric_directions: Mapping[str, str]) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for metric_name, direction in metric_directions.items():
+        metric_key = _require_non_empty_text(metric_name, field_name="metric_directions key")
+        direction_key = _require_non_empty_text(direction, field_name=f"metric_directions['{metric_key}']").lower()
+        if direction_key not in {"asc", "desc"}:
+            raise ValueError(f"metric_directions['{metric_key}'] must be 'asc' or 'desc'.")
+        normalized[metric_key] = direction_key
+    return normalized
+
+
+def _resolve_direction(metric_name: str, metric_directions: Mapping[str, str]) -> str:
+    direction = metric_directions.get(metric_name, _DEFAULT_DIRECTION_BY_METRIC.get(metric_name, "asc"))
+    if direction not in {"asc", "desc"}:
+        raise ValueError(f"Invalid sort direction '{direction}' for metric '{metric_name}'.")
+    return direction
+
+
+def _coerce_metric_value(value: Any, *, metric_name: str, model_id: str) -> float:
+    try:
+        metric_value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Metric '{metric_name}' for model '{model_id}' must be numeric.") from exc
+
+    if not math.isfinite(metric_value):
+        raise ValueError(f"Metric '{metric_name}' for model '{model_id}' must be finite.")
+
+    return metric_value
+
+
+class CompareModels:
+    def __init__(self, *, model_registry: ModelRegistryPort) -> None:
+        self._model_registry = model_registry
+
+    def execute(self, request: application_dto.CompareModelsRequest) -> application_dto.CompareModelsResult:
+        model_ids = _normalize_model_ids(request.model_ids)
+        rank_by = _normalize_rank_by(request.rank_by)
+        metric_directions = _normalize_metric_directions(request.metric_directions)
+
+        rows: list[application_dto.ModelComparisonRow] = []
+        for model_id in model_ids:
+            run_id = self._model_registry.latest_run_id(artifact_root=request.artifacts_dir, model_id=model_id)
+            run_artifacts = self._model_registry.load_run_artifacts(artifact_root=request.artifacts_dir, run_id=run_id)
+
+            metrics_raw = getattr(run_artifacts, "metrics", None)
+            if not isinstance(metrics_raw, Mapping):
+                raise TypeError(f"Loaded artifacts for model '{model_id}' must expose metrics as a mapping.")
+
+            row_metrics: dict[str, application_dto.MetricValue] = {
+                str(metric_name): metric_value for metric_name, metric_value in metrics_raw.items()
+            }
+
+            sort_key: list[float | str] = []
+            for metric_name in rank_by:
+                if metric_name not in row_metrics:
+                    raise ValueError(f"Model '{model_id}' is missing comparison metric '{metric_name}'.")
+
+                metric_value = _coerce_metric_value(row_metrics[metric_name], metric_name=metric_name, model_id=model_id)
+                direction = _resolve_direction(metric_name, metric_directions)
+                sort_key.append(metric_value if direction == "asc" else -metric_value)
+
+            sort_key.append(model_id)
+            sort_key.append(str(run_id))
+
+            rows.append(
+                application_dto.ModelComparisonRow(
+                    rank=0,
+                    model_id=model_id,
+                    run_id=str(run_id),
+                    metrics=row_metrics,
+                    sort_key=tuple(sort_key),
+                )
+            )
+
+        ordered_rows = sorted(rows, key=lambda row: row.sort_key)
+        ranked_rows = [replace(row, rank=index + 1) for index, row in enumerate(ordered_rows)]
+
+        return application_dto.CompareModelsResult(
+            rows=ranked_rows,
+            rank_by=rank_by,
+            metric_directions={metric_name: _resolve_direction(metric_name, metric_directions) for metric_name in rank_by},
+        )
+
+
+__all__ = ["CompareModels"]
+
+

--- a/src/finsight/bootstrap/container.py
+++ b/src/finsight/bootstrap/container.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.application.use_cases.compare_models import CompareModels
 from finsight.application.use_cases.forecast import Forecast
 from finsight.application.use_cases.train_model import TrainModel
 from finsight.config.settings import get_settings
@@ -19,6 +20,7 @@ class AppContainer:
 
     fetch_market_data: FetchMarketData
     train_model: TrainModel
+    compare_models: CompareModels
     forecast: Forecast
 
 
@@ -46,6 +48,7 @@ def build_container() -> AppContainer:
         supported_model_types=settings.model_defaults.training_model_ids(),
         default_interval=settings.stock_data.default_interval,
     )
+    compare_models = CompareModels(model_registry=model_registry)
     forecast = Forecast(
         fetch_market_data=fetch_market_data,
         feature_store=feature_store,
@@ -55,5 +58,6 @@ def build_container() -> AppContainer:
     return AppContainer(
         fetch_market_data=fetch_market_data,
         train_model=train_model,
+        compare_models=compare_models,
         forecast=forecast,
     )

--- a/src/finsight/cli/main.py
+++ b/src/finsight/cli/main.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 
-from finsight.application.dto import TrainModelRequest
+import pandas as pd
+
+from finsight.application.dto import CompareModelsRequest, TrainModelRequest
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
 from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
@@ -34,6 +36,32 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Directory for run artifacts",
     )
 
+    compare_parser = subparsers.add_parser(
+        "compare",
+        help="Compare trained model runs and print a leaderboard table",
+    )
+    compare_model_ids = list(settings.model_defaults.training_model_ids())
+    compare_parser.add_argument(
+        "--model-ids",
+        nargs="+",
+        default=compare_model_ids,
+        help=f"Model IDs to compare (defaults: {', '.join(compare_model_ids)})",
+    )
+    compare_parser.add_argument(
+        "--rank-by",
+        nargs="+",
+        default=[METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY],
+        help=(
+            "Ordered comparison metrics used for ranking "
+            f"(defaults: {METRIC_MAE}, {METRIC_RMSE}, {METRIC_DIRECTION_ACCURACY})"
+        ),
+    )
+    compare_parser.add_argument(
+        "--artifacts-dir",
+        default="artifacts/runs",
+        help="Directory containing model run artifacts",
+    )
+
     return parser
 
 
@@ -62,12 +90,51 @@ def _run_train(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_compare(args: argparse.Namespace) -> int:
+    container = build_container()
+    response = container.compare_models.execute(
+        CompareModelsRequest(
+            model_ids=args.model_ids,
+            rank_by=args.rank_by,
+            artifacts_dir=args.artifacts_dir,
+        )
+    )
+
+    id_to_label = get_settings().model_defaults.id_to_label()
+    rows: list[dict[str, object]] = []
+    for row in response.rows:
+        record: dict[str, object] = {
+            "rank": row.rank,
+            "model": id_to_label.get(row.model_id, row.model_id),
+        }
+        record.update(row.metrics)
+        rows.append(record)
+
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        print("No comparable model runs were found.")
+        return 0
+
+    base_columns = ["rank", "model"]
+    metric_columns = [column for column in response.rank_by if column in frame.columns]
+    remaining_columns = [
+        column for column in frame.columns if column not in base_columns and column not in metric_columns
+    ]
+    ordered_columns = base_columns + metric_columns + sorted(remaining_columns)
+
+    print(frame[ordered_columns].to_string(index=False))
+    return 0
+
+
 def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
 
     if args.command == "train":
         return _run_train(args)
+
+    if args.command == "compare":
+        return _run_compare(args)
 
     parser.error(f"Unknown command: {args.command}")
 

--- a/tests/unit/adapters/web_streamlit/test_compare.py
+++ b/tests/unit/adapters/web_streamlit/test_compare.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from finsight.adapters.web_streamlit.views.compare import _build_comparison_frame
+from finsight.application.dto import CompareModelsResult, ModelComparisonRow
+
+
+def test_build_comparison_frame_orders_columns_and_applies_labels() -> None:
+    result = CompareModelsResult(
+        rows=[
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-12T120000Z__ridge",
+                metrics={"mae": 0.09, "rmse": 0.18, "direction_accuracy": 0.83, "extra": 7},
+                sort_key=(0.09, 0.18, -0.83, "ridge", "2026-04-12T120000Z__ridge"),
+            )
+        ],
+        rank_by=["mae", "rmse", "direction_accuracy"],
+        metric_directions={"mae": "asc", "rmse": "asc", "direction_accuracy": "desc"},
+    )
+
+    frame = _build_comparison_frame(result, label_lookup={"ridge": "Ridge Regression"})
+
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame.columns) == ["rank", "model", "model_id", "run_id", "mae", "rmse", "direction_accuracy", "extra"]
+    assert frame.iloc[0]["model"] == "Ridge Regression"
+    assert frame.iloc[0]["rank"] == 1
+    assert frame.iloc[0]["extra"] == 7
+

--- a/tests/unit/application/test_dto.py
+++ b/tests/unit/application/test_dto.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from finsight.application.dto import (
     BacktestResult,
+    CompareModelsRequest,
+    CompareModelsResult,
     DatasetSpec,
     FeatureSpec,
     FetchMarketDataRequest,
     ForecastRequest,
     ForecastResult,
+    ModelComparisonRow,
     TrainModelRequest,
     TrainModelResult,
 )
@@ -80,6 +83,31 @@ def test_train_model_result_roundtrip_with_specs() -> None:
     restored = TrainModelResult.from_dict(payload)
 
     assert restored == result
+
+
+def test_compare_models_request_and_result_roundtrip() -> None:
+    request = CompareModelsRequest(
+        model_ids=["naive_zero", "ridge"],
+        artifacts_dir="artifacts/runs",
+        rank_by=["mae", "direction_accuracy"],
+        metric_directions={"direction_accuracy": "desc"},
+    )
+    result = CompareModelsResult(
+        rows=[
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-12T120000Z__ridge",
+                metrics={"mae": 0.09, "direction_accuracy": 0.87},
+                sort_key=(0.09, -0.87, "ridge", "2026-04-12T120000Z__ridge"),
+            )
+        ],
+        rank_by=["mae", "direction_accuracy"],
+        metric_directions={"mae": "asc", "direction_accuracy": "desc"},
+    )
+
+    assert CompareModelsRequest.from_dict(request.to_dict()) == request
+    assert CompareModelsResult.from_dict(result.to_dict()) == result
 
 
 def test_forecast_and_backtest_results_are_serializable() -> None:

--- a/tests/unit/application/use_cases/test_compare_models.py
+++ b/tests/unit/application/use_cases/test_compare_models.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from finsight.application.dto import CompareModelsRequest, ModelRunArtifacts
+from finsight.application.use_cases.compare_models import CompareModels
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.ports import ModelRegistryPort
+
+
+@dataclass
+class _StubRegistry(ModelRegistryPort):
+    artifacts_by_model_id: dict[str, ModelRunArtifacts]
+
+    def __post_init__(self) -> None:
+        self.latest_run_calls: list[tuple[str, str]] = []
+        self.load_run_artifact_calls: list[tuple[str, str]] = []
+
+    def create_run_dir(self, *, artifact_root: str, run_id: str) -> str:
+        raise NotImplementedError
+
+    def latest_run_id(self, *, artifact_root: str, model_id: str) -> str:
+        self.latest_run_calls.append((artifact_root, model_id))
+        if model_id not in self.artifacts_by_model_id:
+            raise FileNotFoundError(f"No runs found for model_id '{model_id}' under artifact root: {artifact_root}")
+        return self.artifacts_by_model_id[model_id].run_id
+
+    def save_model(self, *, run_dir: str, model: object) -> None:
+        raise NotImplementedError
+
+    def load_model(self, *, artifact_root: str, run_id: str) -> object:
+        raise NotImplementedError
+
+    def save_metrics(self, *, run_dir: str, metrics):
+        raise NotImplementedError
+
+    def load_metrics(self, *, artifact_root: str, run_id: str):
+        raise NotImplementedError
+
+    def save_manifest(self, *, run_dir: str, manifest):
+        raise NotImplementedError
+
+    def load_manifest(self, *, artifact_root: str, run_id: str):
+        raise NotImplementedError
+
+    def save_predictions(self, *, run_dir: str, predictions):
+        raise NotImplementedError
+
+    def load_run_artifacts(self, *, artifact_root: str, run_id: str) -> ModelRunArtifacts:
+        self.load_run_artifact_calls.append((artifact_root, run_id))
+        for artifacts in self.artifacts_by_model_id.values():
+            if artifacts.run_id == run_id:
+                return artifacts
+        raise FileNotFoundError(f"No run artifacts found for run_id '{run_id}' under artifact root: {artifact_root}")
+
+
+def _make_model_run_artifacts(*, model_id: str, run_id: str, metrics: dict[str, float | int | str]) -> ModelRunArtifacts:
+    return ModelRunArtifacts(
+        run_id=run_id,
+        run_dir=f"artifacts/runs/{run_id}",
+        model_path=f"artifacts/runs/{run_id}/model.joblib",
+        metrics_path=f"artifacts/runs/{run_id}/metrics.json",
+        manifest_path=f"artifacts/runs/{run_id}/manifest.json",
+        predictions_path=f"artifacts/runs/{run_id}/predictions.csv",
+        model=object(),
+        metrics=metrics,
+        manifest={"model_id": model_id, "feature_columns": ["f1", "f2"]},
+    )
+
+
+def test_compare_models_ranks_by_multiple_metrics_with_expected_direction() -> None:
+    registry = _StubRegistry(
+        artifacts_by_model_id={
+            "alpha": _make_model_run_artifacts(
+                model_id="alpha",
+                run_id="2026-04-11T120000Z__alpha",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.22, METRIC_DIRECTION_ACCURACY: 0.80},
+            ),
+            "beta": _make_model_run_artifacts(
+                model_id="beta",
+                run_id="2026-04-12T120000Z__beta",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.21, METRIC_DIRECTION_ACCURACY: 0.90},
+            ),
+        }
+    )
+
+    result = CompareModels(model_registry=registry).execute(
+        CompareModelsRequest(
+            model_ids=["alpha", "beta"],
+            rank_by=[METRIC_MAE, METRIC_DIRECTION_ACCURACY],
+        )
+    )
+
+    assert [row.rank for row in result.rows] == [1, 2]
+    assert [row.model_id for row in result.rows] == ["beta", "alpha"]
+    assert result.rank_by == [METRIC_MAE, METRIC_DIRECTION_ACCURACY]
+    assert result.metric_directions == {METRIC_MAE: "asc", METRIC_DIRECTION_ACCURACY: "desc"}
+    assert registry.latest_run_calls == [("artifacts/runs", "alpha"), ("artifacts/runs", "beta")]
+    assert registry.load_run_artifact_calls == [
+        ("artifacts/runs", "2026-04-11T120000Z__alpha"),
+        ("artifacts/runs", "2026-04-12T120000Z__beta"),
+    ]
+
+
+def test_compare_models_uses_model_id_as_deterministic_tie_break() -> None:
+    registry = _StubRegistry(
+        artifacts_by_model_id={
+            "beta": _make_model_run_artifacts(
+                model_id="beta",
+                run_id="2026-04-12T120000Z__beta",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.21, METRIC_DIRECTION_ACCURACY: 0.80},
+            ),
+            "alpha": _make_model_run_artifacts(
+                model_id="alpha",
+                run_id="2026-04-11T120000Z__alpha",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.21, METRIC_DIRECTION_ACCURACY: 0.80},
+            ),
+        }
+    )
+
+    result = CompareModels(model_registry=registry).execute(
+        CompareModelsRequest(
+            model_ids=["beta", "alpha"],
+            rank_by=[METRIC_MAE, METRIC_RMSE],
+        )
+    )
+
+    assert [row.model_id for row in result.rows] == ["alpha", "beta"]
+    assert [row.run_id for row in result.rows] == [
+        "2026-04-11T120000Z__alpha",
+        "2026-04-12T120000Z__beta",
+    ]
+    assert result.rows[0].sort_key[-2:] == ("alpha", "2026-04-11T120000Z__alpha")
+
+
+def test_compare_models_rejects_duplicate_model_ids() -> None:
+    registry = _StubRegistry(artifacts_by_model_id={})
+
+    with pytest.raises(ValueError, match="model_ids must be unique"):
+        CompareModels(model_registry=registry).execute(
+            CompareModelsRequest(model_ids=["alpha", "alpha"], rank_by=[METRIC_MAE])
+        )
+
+
+def test_compare_models_rejects_missing_rank_metric() -> None:
+    registry = _StubRegistry(
+        artifacts_by_model_id={
+            "alpha": _make_model_run_artifacts(
+                model_id="alpha",
+                run_id="2026-04-11T120000Z__alpha",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.22},
+            ),
+        }
+    )
+
+    with pytest.raises(ValueError, match="missing comparison metric"):
+        CompareModels(model_registry=registry).execute(
+            CompareModelsRequest(model_ids=["alpha"], rank_by=[METRIC_MAE, METRIC_DIRECTION_ACCURACY])
+        )
+

--- a/tests/unit/bootstrap/test_container.py
+++ b/tests/unit/bootstrap/test_container.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from finsight.bootstrap import container as container_module
+from finsight.config.settings import Settings
+from finsight.application.use_cases.compare_models import CompareModels
+
+
+def test_build_container_exposes_compare_models_use_case(monkeypatch) -> None:
+    container_module.build_container.cache_clear()
+    monkeypatch.setattr(container_module, "get_settings", lambda: Settings())
+
+    app_container = container_module.build_container()
+
+    assert isinstance(app_container.compare_models, CompareModels)
+    assert app_container.compare_models is app_container.compare_models
+

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -117,8 +117,6 @@ def test_run_compare_prints_leaderboard_table(monkeypatch, capsys) -> None:
     captured = capsys.readouterr().out
     assert exit_code == 0
     assert "Naive (Zero)" in captured
-    assert "naive_zero" in captured
-    assert "2026-04-12T120000Z__naive_zero" in captured
     assert "mae" in captured
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -2,7 +2,9 @@ import pytest
 
 import finsight.cli.main as cli_main
 from finsight.cli.main import _build_parser, _run_train
+from finsight.application.dto import CompareModelsResult, ModelComparisonRow
 from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.config.settings import ModelCatalogEntry, ModelDefaults, Settings, TickerCatalogSettings
 
 
 def test_train_parser_accepts_train_without_tickers_arg() -> None:
@@ -26,6 +28,18 @@ def test_train_parser_rejects_interval_arg() -> None:
 
     with pytest.raises(SystemExit):
         parser.parse_args(["train", "--cutoff", "2025-06-01", "--interval", "1d"])
+
+
+def test_compare_parser_accepts_compare_model_ids_and_rank_by() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(
+        ["compare", "--model-ids", "naive_zero", "ridge", "--rank-by", "mae", "direction_accuracy"]
+    )
+
+    assert args.command == "compare"
+    assert args.model_ids == ["naive_zero", "ridge"]
+    assert args.rank_by == ["mae", "direction_accuracy"]
 
 
 def test_run_train_prints_metrics_using_canonical_metric_keys(monkeypatch, capsys) -> None:
@@ -59,5 +73,52 @@ def test_run_train_prints_metrics_using_canonical_metric_keys(monkeypatch, capsy
     assert exit_code == 0
     assert "[naive_zero] run_dir=artifacts/runs/example" in captured
     assert "MAE=0.100000 RMSE=0.200000 DirectionAcc=0.7500" in captured
+
+
+def test_run_compare_prints_leaderboard_table(monkeypatch, capsys) -> None:
+    class _StubCompareModels:
+        @staticmethod
+        def execute(_request):
+            return CompareModelsResult(
+                rows=[
+                    ModelComparisonRow(
+                        rank=1,
+                        model_id="naive_zero",
+                        run_id="2026-04-12T120000Z__naive_zero",
+                        metrics={METRIC_MAE: 0.1, METRIC_RMSE: 0.2, METRIC_DIRECTION_ACCURACY: 0.75},
+                        sort_key=(0.1, 0.2, -0.75, "naive_zero", "2026-04-12T120000Z__naive_zero"),
+                    )
+                ],
+                rank_by=[METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY],
+                metric_directions={METRIC_MAE: "asc", METRIC_RMSE: "asc", METRIC_DIRECTION_ACCURACY: "desc"},
+            )
+
+    class _StubContainer:
+        compare_models = _StubCompareModels()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+    monkeypatch.setattr(
+        cli_main,
+        "get_settings",
+        lambda: Settings(
+            model_defaults=ModelDefaults(
+                catalog=(
+                    ModelCatalogEntry(id="naive_zero", label="Naive (Zero)", supports_training=True, supports_prediction=True),
+                ),
+                default_model_id="naive_zero",
+            ),
+            ticker_catalog=TickerCatalogSettings(entries=()),
+        ),
+    )
+
+    args = _build_parser().parse_args(["compare", "--model-ids", "naive_zero"])
+    exit_code = cli_main._run_compare(args)
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Naive (Zero)" in captured
+    assert "naive_zero" in captured
+    assert "2026-04-12T120000Z__naive_zero" in captured
+    assert "mae" in captured
 
 


### PR DESCRIPTION
This pull request introduces a new "Compare Models" feature, enabling deterministic leaderboard ranking of trained model runs based on configurable metrics. It adds a new use case, CLI command, and Streamlit page, along with supporting data transfer objects (DTOs) and container wiring. The documentation is updated to describe this new functionality.

**New Compare Models Feature**

- Added `CompareModels` use case for ranking the latest run of each model into a deterministic leaderboard, based on user-selected metrics and sort directions. 
- Introduced new DTOs: `CompareModelsRequest`, `CompareModelsResult`, and `ModelComparisonRow`, with serialization/deserialization support. [

**User Interface Integration**

- Implemented a new Streamlit view in `compare.py` for interactive model comparison, allowing users to select models and ranking metrics, and displaying the leaderboard as a table.
- Added a new CLI command `compare` for generating and printing the leaderboard from the command line, with arguments for models, metrics, and artifact directory. 

**Container and Wiring**

- Registered the `CompareModels` use case in the application container, making it available to both the CLI and Streamlit interfaces. 

**Documentation Updates**

- Updated the architecture overview documentation to describe the new compare models use case, CLI integration, and data flow. 

These changes collectively enable users to compare trained models easily and reproducibly, both through the web UI and CLI.