### PR TITLE
Chore/issues/21 wire container adapters to new use cases

### DIFF
--- a/src/finsight/adapters/web_streamlit/presenters.py
+++ b/src/finsight/adapters/web_streamlit/presenters.py
@@ -1,0 +1,135 @@
+"""
+Presenters for converting domain/DTO objects into display-ready formats.
+
+This module provides pure formatting functions that convert use-case outputs
+into data structures optimized for UI rendering. Presenters do not contain
+Streamlit calls (st.write, st.dataframe, etc.) to maintain separation of
+concerns and improve testability.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import pandas as pd
+
+import finsight.application.dto as application_dto
+
+
+class ForecastPresenter:
+    """Converts ForecastResult into display-ready formats."""
+
+    @staticmethod
+    def format_predictions_table(result: application_dto.ForecastResult) -> pd.DataFrame:
+        """
+        Convert forecast predictions into a DataFrame for tabular display.
+
+        Args:
+            result: ForecastResult from the Forecast use case.
+
+        Returns:
+            DataFrame with predictions, or empty DataFrame if no predictions.
+
+        Raises:
+            ValueError: If predictions cannot be converted to a valid DataFrame.
+        """
+        if not result.predictions:
+            return pd.DataFrame()
+
+        try:
+            frame = pd.DataFrame(result.predictions)
+            return frame
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Failed to convert predictions to DataFrame.") from exc
+
+    @staticmethod
+    def format_price_chart_data(
+        result: application_dto.ForecastResult,
+    ) -> pd.DataFrame | None:
+        """
+        Extract date and pred_close columns for price chart visualization.
+
+        Returns None if required columns are missing or if the DataFrame is empty.
+        Otherwise returns a DataFrame with date as the index and pred_close as the value.
+
+        Args:
+            result: ForecastResult from the Forecast use case.
+
+        Returns:
+            DataFrame indexed by date with pred_close column, or None if chart cannot be rendered.
+        """
+        predictions_df = ForecastPresenter.format_predictions_table(result)
+        if predictions_df.empty:
+            return None
+
+        required_cols = {"date", "pred_close"}
+        if not required_cols.issubset(predictions_df.columns):
+            return None
+
+        try:
+            chart_df = predictions_df[["date", "pred_close"]].copy()
+            # Forecast dates are emitted as ISO calendar dates (YYYY-MM-DD).
+            chart_df["date"] = pd.to_datetime(chart_df["date"], format="%Y-%m-%d", errors="coerce")
+            chart_df = chart_df.dropna(subset=["date"]).set_index("date")
+
+            if chart_df.empty:
+                return None
+
+            return chart_df
+        except (TypeError, KeyError, ValueError):
+            return None
+
+
+class ComparisonPresenter:
+    """Converts CompareModelsResult into display-ready formats."""
+
+    @staticmethod
+    def format_leaderboard_frame(
+        result: application_dto.CompareModelsResult,
+        *,
+        label_lookup: Mapping[str, str],
+    ) -> pd.DataFrame:
+        """
+        Convert comparison result into a formatted leaderboard DataFrame.
+
+        Columns are ordered: rank, model (with label), model_id, run_id, then
+        ranking metrics (in priority order), then remaining columns (sorted).
+
+        Args:
+            result: CompareModelsResult from the CompareModels use case.
+            label_lookup: Mapping from model_id to human-readable label.
+
+        Returns:
+            Formatted DataFrame with columns in display order, or empty DataFrame if no rows.
+        """
+        if not result.rows:
+            return pd.DataFrame()
+
+        rows: list[dict[str, object]] = []
+        for row in result.rows:
+            record: dict[str, object] = {
+                "rank": row.rank,
+                "model": label_lookup.get(row.model_id, row.model_id),
+                "model_id": row.model_id,
+                "run_id": row.run_id,
+            }
+            record.update(row.metrics)
+            rows.append(record)
+
+        frame = pd.DataFrame(rows)
+        if frame.empty:
+            return frame
+
+        # Reorder columns: rank, model, model_id, run_id, ranking metrics, then others
+        base_columns = ["rank", "model", "model_id", "run_id"]
+        metric_columns = [column for column in result.rank_by if column in frame.columns]
+        remaining_columns = [
+            column
+            for column in frame.columns
+            if column not in base_columns and column not in metric_columns
+        ]
+        return frame[base_columns + metric_columns + sorted(remaining_columns)]
+
+
+__all__ = ["ForecastPresenter", "ComparisonPresenter"]
+
+

--- a/src/finsight/adapters/web_streamlit/presenters.py
+++ b/src/finsight/adapters/web_streamlit/presenters.py
@@ -39,7 +39,7 @@ class ForecastPresenter:
             frame = pd.DataFrame(result.predictions)
             return frame
         except (TypeError, ValueError) as exc:
-            raise ValueError("Failed to convert predictions to DataFrame.") from exc
+            raise ValueError(f"Failed to convert predictions to DataFrame: {exc}") from exc
 
     @staticmethod
     def format_price_chart_data(
@@ -57,15 +57,15 @@ class ForecastPresenter:
         Returns:
             DataFrame indexed by date with pred_close column, or None if chart cannot be rendered.
         """
-        predictions_df = ForecastPresenter.format_predictions_table(result)
-        if predictions_df.empty:
-            return None
-
-        required_cols = {"date", "pred_close"}
-        if not required_cols.issubset(predictions_df.columns):
-            return None
-
         try:
+            predictions_df = ForecastPresenter.format_predictions_table(result)
+            if predictions_df.empty:
+                return None
+
+            required_cols = {"date", "pred_close"}
+            if not required_cols.issubset(predictions_df.columns):
+                return None
+
             chart_df = predictions_df[["date", "pred_close"]].copy()
             # Forecast dates are emitted as ISO calendar dates (YYYY-MM-DD).
             chart_df["date"] = pd.to_datetime(chart_df["date"], format="%Y-%m-%d", errors="coerce")

--- a/src/finsight/adapters/web_streamlit/views/compare.py
+++ b/src/finsight/adapters/web_streamlit/views/compare.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-
-import pandas as pd
 import streamlit as st
 
-from finsight.application.dto import CompareModelsRequest, CompareModelsResult
+from finsight.application.dto import CompareModelsRequest
+from finsight.adapters.web_streamlit.presenters import ComparisonPresenter
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
 from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
@@ -23,29 +21,6 @@ _METRIC_LABELS = {
 def _compare_models_uc():
     return build_container().compare_models
 
-
-def _build_comparison_frame(result: CompareModelsResult, *, label_lookup: Mapping[str, str]) -> pd.DataFrame:
-    rows: list[dict[str, object]] = []
-    for row in result.rows:
-        record: dict[str, object] = {
-            "rank": row.rank,
-            "model": label_lookup.get(row.model_id, row.model_id),
-            "model_id": row.model_id,
-            "run_id": row.run_id,
-        }
-        record.update(row.metrics)
-        rows.append(record)
-
-    frame = pd.DataFrame(rows)
-    if frame.empty:
-        return frame
-
-    base_columns = ["rank", "model", "model_id", "run_id"]
-    metric_columns = [column for column in result.rank_by if column in frame.columns]
-    remaining_columns = [
-        column for column in frame.columns if column not in base_columns and column not in metric_columns
-    ]
-    return frame[base_columns + metric_columns + sorted(remaining_columns)]
 
 
 def render():
@@ -112,7 +87,7 @@ def render():
         st.error(f"Leaderboard generation failed unexpectedly: {error}")
         return
 
-    frame = _build_comparison_frame(result, label_lookup=id_to_label)
+    frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup=id_to_label)
     if frame.empty:
         st.warning("No comparison rows were returned.")
         return

--- a/src/finsight/adapters/web_streamlit/views/predict.py
+++ b/src/finsight/adapters/web_streamlit/views/predict.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from finsight.application.dto import FetchMarketDataRequest, ForecastRequest, ForecastResult
 from finsight.application.use_cases.fetch_market_data import FetchMarketData
 from finsight.application.use_cases.forecast import Forecast
+from finsight.adapters.web_streamlit.presenters import ForecastPresenter
 from finsight.adapters.web_streamlit.ticker_options import build_ticker_select_items
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
@@ -54,24 +55,19 @@ def _render_market_data(ticker: str) -> None:
 
 
 def _render_forecast(result: ForecastResult) -> None:
-    import pandas as pd
-
-    predictions = result.predictions
-    frame = pd.DataFrame(predictions)
-    if frame.empty:
+    """Render forecast results using presenter formatting."""
+    predictions_frame = ForecastPresenter.format_predictions_table(result)
+    if predictions_frame.empty:
         st.warning("No forecast rows were returned.")
         return
 
     st.subheader("Forecast Results")
-    st.dataframe(frame, use_container_width=True)
+    st.dataframe(predictions_frame, use_container_width=True)
 
-    if {"date", "pred_close"}.issubset(frame.columns):
-        chart_df = frame[["date", "pred_close"]].copy()
-        chart_df["date"] = pd.to_datetime(chart_df["date"], errors="coerce")
-        chart_df = chart_df.dropna(subset=["date"]).set_index("date")
-        if not chart_df.empty:
-            st.subheader("Predicted Close Price")
-            st.line_chart(chart_df["pred_close"])
+    chart_df = ForecastPresenter.format_price_chart_data(result)
+    if chart_df is not None:
+        st.subheader("Predicted Close Price")
+        st.line_chart(chart_df["pred_close"])
 
 
 def render():

--- a/tests/unit/adapters/web_streamlit/test_compare.py
+++ b/tests/unit/adapters/web_streamlit/test_compare.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import pandas as pd
 
-from finsight.adapters.web_streamlit.views.compare import _build_comparison_frame
+from finsight.adapters.web_streamlit.presenters import ComparisonPresenter
 from finsight.application.dto import CompareModelsResult, ModelComparisonRow
 
 
 def test_build_comparison_frame_orders_columns_and_applies_labels() -> None:
+    """Test that comparison frame formatting works correctly (via presenter)."""
     result = CompareModelsResult(
         rows=[
             ModelComparisonRow(
@@ -21,7 +22,7 @@ def test_build_comparison_frame_orders_columns_and_applies_labels() -> None:
         metric_directions={"mae": "asc", "rmse": "asc", "direction_accuracy": "desc"},
     )
 
-    frame = _build_comparison_frame(result, label_lookup={"ridge": "Ridge Regression"})
+    frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={"ridge": "Ridge Regression"})
 
     assert isinstance(frame, pd.DataFrame)
     assert list(frame.columns) == ["rank", "model", "model_id", "run_id", "mae", "rmse", "direction_accuracy", "extra"]

--- a/tests/unit/adapters/web_streamlit/test_presenters.py
+++ b/tests/unit/adapters/web_streamlit/test_presenters.py
@@ -1,0 +1,361 @@
+"""Tests for presenter formatting functions."""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from finsight.adapters.web_streamlit.presenters import ComparisonPresenter, ForecastPresenter
+from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow
+
+
+class TestForecastPresenter:
+    """Tests for ForecastPresenter formatting logic."""
+
+    def test_format_predictions_table_returns_empty_dataframe_for_empty_predictions(self) -> None:
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=[],
+        )
+
+        frame = ForecastPresenter.format_predictions_table(result)
+
+        assert isinstance(frame, pd.DataFrame)
+        assert frame.empty
+
+    def test_format_predictions_table_converts_predictions_to_dataframe(self) -> None:
+        predictions = [
+            {"date": "2026-04-15", "pred_close": 150.0},
+            {"date": "2026-04-16", "pred_close": 151.5},
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        frame = ForecastPresenter.format_predictions_table(result)
+
+        assert isinstance(frame, pd.DataFrame)
+        assert len(frame) == 2
+        assert list(frame.columns) == ["date", "pred_close"]
+        assert frame.iloc[0]["pred_close"] == 150.0
+
+    def test_format_predictions_table_preserves_all_columns(self) -> None:
+        predictions = [
+            {"date": "2026-04-15", "pred_close": 150.0, "pred_volume": 1000000},
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        frame = ForecastPresenter.format_predictions_table(result)
+
+        assert set(frame.columns) == {"date", "pred_close", "pred_volume"}
+
+    def test_format_price_chart_data_returns_none_for_empty_predictions(self) -> None:
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=[],
+        )
+
+        chart_df = ForecastPresenter.format_price_chart_data(result)
+
+        assert chart_df is None
+
+    def test_format_price_chart_data_returns_none_if_missing_date_column(self) -> None:
+        predictions = [
+            {"pred_close": 150.0},  # Missing date column
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        chart_df = ForecastPresenter.format_price_chart_data(result)
+
+        assert chart_df is None
+
+    def test_format_price_chart_data_returns_none_if_missing_pred_close_column(self) -> None:
+        predictions = [
+            {"date": "2026-04-15"},  # Missing pred_close column
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        chart_df = ForecastPresenter.format_price_chart_data(result)
+
+        assert chart_df is None
+
+    def test_format_price_chart_data_extracts_and_indexes_by_date(self) -> None:
+        predictions = [
+            {"date": "2026-04-15", "pred_close": 150.0, "extra": "ignored"},
+            {"date": "2026-04-16", "pred_close": 151.5, "extra": "ignored"},
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        chart_df = ForecastPresenter.format_price_chart_data(result)
+
+        assert chart_df is not None
+        assert isinstance(chart_df, pd.DataFrame)
+        assert list(chart_df.columns) == ["pred_close"]
+        assert chart_df.index.name == "date"
+        assert len(chart_df) == 2
+
+    def test_format_price_chart_data_handles_invalid_dates(self) -> None:
+        predictions = [
+            {"date": "invalid-date", "pred_close": 150.0},
+            {"date": "2026-04-16", "pred_close": 151.5},
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        chart_df = ForecastPresenter.format_price_chart_data(result)
+
+        # Should drop invalid date rows and return only valid ones
+        assert chart_df is not None
+        assert len(chart_df) == 1
+        assert chart_df.iloc[0]["pred_close"] == 151.5
+
+    def test_format_price_chart_data_returns_none_if_all_dates_invalid(self) -> None:
+        predictions = [
+            {"date": "not-a-date", "pred_close": 150.0},
+            {"date": "also-invalid", "pred_close": 151.5},
+        ]
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=predictions,
+        )
+
+        chart_df = ForecastPresenter.format_price_chart_data(result)
+
+        assert chart_df is None
+
+
+class TestComparisonPresenter:
+    """Tests for ComparisonPresenter formatting logic."""
+
+    def test_format_leaderboard_frame_returns_empty_dataframe_for_empty_rows(self) -> None:
+        result = CompareModelsResult(
+            rows=[],
+            rank_by=["mae", "rmse"],
+            metric_directions={"mae": "asc", "rmse": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        assert isinstance(frame, pd.DataFrame)
+        assert frame.empty
+
+    def test_format_leaderboard_frame_includes_base_columns(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09},
+                sort_key=(0.09, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae"],
+            metric_directions={"mae": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        assert "rank" in frame.columns
+        assert "model" in frame.columns
+        assert "model_id" in frame.columns
+        assert "run_id" in frame.columns
+
+    def test_format_leaderboard_frame_applies_label_lookup(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09},
+                sort_key=(0.09, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae"],
+            metric_directions={"mae": "asc"},
+        )
+        label_lookup = {"ridge": "Ridge Regression"}
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup=label_lookup)
+
+        assert frame.iloc[0]["model"] == "Ridge Regression"
+        assert frame.iloc[0]["model_id"] == "ridge"
+
+    def test_format_leaderboard_frame_uses_model_id_as_fallback_label(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09},
+                sort_key=(0.09, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae"],
+            metric_directions={"mae": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        # Should use model_id as fallback when no label found
+        assert frame.iloc[0]["model"] == "ridge"
+
+    def test_format_leaderboard_frame_orders_columns_correctly(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09, "rmse": 0.18, "direction_accuracy": 0.83, "extra": 7},
+                sort_key=(0.09, 0.18, -0.83, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae", "rmse", "direction_accuracy"],
+            metric_directions={"mae": "asc", "rmse": "asc", "direction_accuracy": "desc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        expected_columns = ["rank", "model", "model_id", "run_id", "mae", "rmse", "direction_accuracy", "extra"]
+        assert list(frame.columns) == expected_columns
+
+    def test_format_leaderboard_frame_puts_ranking_metrics_first(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"extra": 7, "mae": 0.09, "rmse": 0.18},
+                sort_key=(0.09, 0.18, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae", "rmse"],
+            metric_directions={"mae": "asc", "rmse": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        # Ranking metrics should come before other metrics
+        mae_idx = list(frame.columns).index("mae")
+        rmse_idx = list(frame.columns).index("rmse")
+        extra_idx = list(frame.columns).index("extra")
+        assert mae_idx < rmse_idx < extra_idx
+
+    def test_format_leaderboard_frame_sorts_remaining_columns_alphabetically(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"zebra": 1, "apple": 2, "banana": 3, "mae": 0.09},
+                sort_key=(0.09, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae"],
+            metric_directions={"mae": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        # Other columns should be sorted alphabetically after ranking metrics
+        remaining_after_rank = list(frame.columns)[5:]  # After rank, model, model_id, run_id, mae
+        assert remaining_after_rank == ["apple", "banana", "zebra"]
+
+    def test_format_leaderboard_frame_preserves_data_values(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09, "rmse": 0.18},
+                sort_key=(0.09, 0.18, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae", "rmse"],
+            metric_directions={"mae": "asc", "rmse": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        assert frame.iloc[0]["rank"] == 1
+        assert frame.iloc[0]["model_id"] == "ridge"
+        assert frame.iloc[0]["run_id"] == "2026-04-10T120000Z__ridge"
+        assert frame.iloc[0]["mae"] == 0.09
+        assert frame.iloc[0]["rmse"] == 0.18
+
+    def test_format_leaderboard_frame_handles_multiple_rows(self) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09},
+                sort_key=(0.09, "ridge", "2026-04-10T120000Z__ridge"),
+            ),
+            ModelComparisonRow(
+                rank=2,
+                model_id="linear",
+                run_id="2026-04-10T120000Z__linear",
+                metrics={"mae": 0.12},
+                sort_key=(0.12, "linear", "2026-04-10T120000Z__linear"),
+            ),
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae"],
+            metric_directions={"mae": "asc"},
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        assert len(frame) == 2
+        assert frame.iloc[0]["rank"] == 1
+        assert frame.iloc[1]["rank"] == 2
+        assert frame.iloc[0]["model_id"] == "ridge"
+        assert frame.iloc[1]["model_id"] == "linear"
+

--- a/tests/unit/adapters/web_streamlit/test_presenters.py
+++ b/tests/unit/adapters/web_streamlit/test_presenters.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import pytest
 
 from finsight.adapters.web_streamlit.presenters import ComparisonPresenter, ForecastPresenter
 from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow

--- a/tests/unit/adapters/web_streamlit/test_presenters.py
+++ b/tests/unit/adapters/web_streamlit/test_presenters.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import pandas as pd
+import pytest
 
 from finsight.adapters.web_streamlit.presenters import ComparisonPresenter, ForecastPresenter
 from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow
@@ -56,6 +57,22 @@ class TestForecastPresenter:
         frame = ForecastPresenter.format_predictions_table(result)
 
         assert set(frame.columns) == {"date", "pred_close", "pred_volume"}
+
+    def test_format_predictions_table_raises_value_error_when_dataframe_conversion_fails(self, monkeypatch) -> None:
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=[{"date": "2026-04-15", "pred_close": 150.0}],
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise ValueError("bad frame")
+
+        monkeypatch.setattr("finsight.adapters.web_streamlit.presenters.pd.DataFrame", _boom)
+
+        with pytest.raises(ValueError, match="Failed to convert predictions to DataFrame"):
+            ForecastPresenter.format_predictions_table(result)
 
     def test_format_price_chart_data_returns_none_for_empty_predictions(self) -> None:
         result = ForecastResult(
@@ -153,6 +170,22 @@ class TestForecastPresenter:
         chart_df = ForecastPresenter.format_price_chart_data(result)
 
         assert chart_df is None
+
+    def test_format_price_chart_data_returns_none_when_predictions_table_raises(self, monkeypatch) -> None:
+        result = ForecastResult(
+            model_id="ridge",
+            ticker="AAPL",
+            horizon_days=7,
+            predictions=[{"date": "2026-04-15", "pred_close": 150.0}],
+        )
+
+        monkeypatch.setattr(
+            ForecastPresenter,
+            "format_predictions_table",
+            staticmethod(lambda _result: (_ for _ in ()).throw(ValueError("boom"))),
+        )
+
+        assert ForecastPresenter.format_price_chart_data(result) is None
 
 
 class TestComparisonPresenter:
@@ -357,4 +390,30 @@ class TestComparisonPresenter:
         assert frame.iloc[1]["rank"] == 2
         assert frame.iloc[0]["model_id"] == "ridge"
         assert frame.iloc[1]["model_id"] == "linear"
+
+    def test_format_leaderboard_frame_handles_empty_dataframe_after_construction(self, monkeypatch) -> None:
+        rows = [
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="2026-04-10T120000Z__ridge",
+                metrics={"mae": 0.09},
+                sort_key=(0.09, "ridge", "2026-04-10T120000Z__ridge"),
+            )
+        ]
+        result = CompareModelsResult(
+            rows=rows,
+            rank_by=["mae"],
+            metric_directions={"mae": "asc"},
+        )
+
+        real_dataframe = pd.DataFrame
+        monkeypatch.setattr(
+            "finsight.adapters.web_streamlit.presenters.pd.DataFrame",
+            lambda *_args, **_kwargs: real_dataframe(),
+        )
+
+        frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={})
+
+        assert frame.empty
 

--- a/tests/unit/adapters/web_streamlit/test_views_presenter_wiring.py
+++ b/tests/unit/adapters/web_streamlit/test_views_presenter_wiring.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+
+import finsight.adapters.web_streamlit.views.compare as compare_view
+import finsight.adapters.web_streamlit.views.predict as predict_view
+from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow
+
+
+class _Ctx:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _ButtonCol(_Ctx):
+    def __init__(self, returns: dict[str, bool] | None = None) -> None:
+        self._returns = returns or {}
+
+    def button(self, label: str, **_kwargs) -> bool:
+        return self._returns.get(label, False)
+
+
+def test_compare_render_shows_info_when_form_not_submitted(monkeypatch) -> None:
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compare_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: ("ridge",),
+        id_to_label=lambda: {"ridge": "Ridge"},
+    )))
+    monkeypatch.setattr(compare_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "info", lambda msg: events.append(("info", msg)))
+    monkeypatch.setattr(compare_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(compare_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(compare_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
+    monkeypatch.setattr(compare_view.st, "form_submit_button", lambda _label: False)
+
+    compare_view.render()
+
+    assert ("info", "Choose models and ranking metrics, then build the leaderboard.") in events
+
+
+def test_compare_render_happy_path_renders_dataframe_and_caption(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(compare_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: ("ridge",),
+        id_to_label=lambda: {"ridge": "Ridge"},
+    )))
+    monkeypatch.setattr(compare_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "info", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(compare_view.st, "error", lambda msg: events.append(("error", msg)))
+    monkeypatch.setattr(compare_view.st, "subheader", lambda msg: events.append(("subheader", msg)))
+    monkeypatch.setattr(compare_view.st, "dataframe", lambda frame, **_kwargs: events.append(("dataframe", frame)))
+    monkeypatch.setattr(compare_view.st, "caption", lambda msg: events.append(("caption", msg)))
+    monkeypatch.setattr(compare_view.st, "form", lambda _name: _Ctx())
+
+    selections = {
+        "Models to compare": ["ridge"],
+        "Ranking metrics": ["mae", "rmse"],
+    }
+    monkeypatch.setattr(compare_view.st, "multiselect", lambda label, _options, **_kwargs: selections[label])
+    monkeypatch.setattr(compare_view.st, "form_submit_button", lambda _label: True)
+
+    result = CompareModelsResult(
+        rows=[
+            ModelComparisonRow(
+                rank=1,
+                model_id="ridge",
+                run_id="run_1",
+                metrics={"mae": 0.1, "rmse": 0.2},
+                sort_key=(0.1, 0.2, "ridge", "run_1"),
+            )
+        ],
+        rank_by=["mae", "rmse"],
+        metric_directions={"mae": "asc", "rmse": "asc"},
+    )
+
+    uc = SimpleNamespace(execute=lambda _req: result)
+    monkeypatch.setattr(compare_view, "_compare_models_uc", lambda: uc)
+    monkeypatch.setattr(
+        compare_view.ComparisonPresenter,
+        "format_leaderboard_frame",
+        staticmethod(lambda _result, *, label_lookup: pd.DataFrame([{"rank": 1, "model": label_lookup["ridge"]}])),
+    )
+
+    compare_view.render()
+
+    assert ("subheader", "Leaderboard") in events
+    assert any(event[0] == "dataframe" for event in events)
+    assert any(event[0] == "caption" and "Ranking priority:" in str(event[1]) for event in events)
+    assert not [event for event in events if event[0] in {"warning", "error"}]
+
+
+def test_compare_render_shows_error_when_use_case_raises_value_error(monkeypatch) -> None:
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compare_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: ("ridge",),
+        id_to_label=lambda: {"ridge": "Ridge"},
+    )))
+    monkeypatch.setattr(compare_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "info", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "warning", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "error", lambda msg: events.append(("error", msg)))
+    monkeypatch.setattr(compare_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(compare_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
+    monkeypatch.setattr(compare_view.st, "form_submit_button", lambda _label: True)
+
+    uc = SimpleNamespace(execute=lambda _req: (_ for _ in ()).throw(ValueError("bad request")))
+    monkeypatch.setattr(compare_view, "_compare_models_uc", lambda: uc)
+
+    compare_view.render()
+
+    assert any("Unable to build leaderboard" in msg for kind, msg in events if kind == "error")
+
+
+def test_compare_render_shows_warning_when_no_training_models(monkeypatch) -> None:
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compare_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: (),
+        id_to_label=lambda: {},
+    )))
+    monkeypatch.setattr(compare_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "info", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "warning", lambda msg: events.append(("warning", msg)))
+
+    compare_view.render()
+
+    assert ("warning", "No training-enabled models are configured.") in events
+
+
+def test_compare_render_warns_when_presenter_returns_empty_frame(monkeypatch) -> None:
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(compare_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: ("ridge",),
+        id_to_label=lambda: {"ridge": "Ridge"},
+    )))
+    monkeypatch.setattr(compare_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "info", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "error", lambda _msg: None)
+    monkeypatch.setattr(compare_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(compare_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(compare_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
+    monkeypatch.setattr(compare_view.st, "form_submit_button", lambda _label: True)
+
+    result = CompareModelsResult(rows=[], rank_by=["mae"], metric_directions={"mae": "asc"})
+    monkeypatch.setattr(compare_view, "_compare_models_uc", lambda: SimpleNamespace(execute=lambda _req: result))
+    monkeypatch.setattr(
+        compare_view.ComparisonPresenter,
+        "format_leaderboard_frame",
+        staticmethod(lambda _result, *, label_lookup: pd.DataFrame()),
+    )
+
+    compare_view.render()
+
+    assert ("warning", "No comparison rows were returned.") in events
+
+
+def test_predict_render_forecast_warns_when_predictions_are_empty(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    result = ForecastResult(model_id="ridge", ticker="AAPL", horizon_days=3, predictions=[])
+
+    monkeypatch.setattr(
+        predict_view.ForecastPresenter,
+        "format_predictions_table",
+        staticmethod(lambda _result: pd.DataFrame()),
+    )
+    monkeypatch.setattr(
+        predict_view.ForecastPresenter,
+        "format_price_chart_data",
+        staticmethod(lambda _result: None),
+    )
+    monkeypatch.setattr(predict_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(predict_view.st, "subheader", lambda msg: events.append(("subheader", msg)))
+    monkeypatch.setattr(predict_view.st, "dataframe", lambda *_args, **_kwargs: events.append(("dataframe", None)))
+    monkeypatch.setattr(predict_view.st, "line_chart", lambda *_args, **_kwargs: events.append(("line_chart", None)))
+
+    predict_view._render_forecast(result)
+
+    assert ("warning", "No forecast rows were returned.") in events
+    assert not any(kind == "dataframe" for kind, _ in events)
+    assert not any(kind == "line_chart" for kind, _ in events)
+
+
+def test_predict_render_forecast_renders_table_and_chart(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    result = ForecastResult(model_id="ridge", ticker="AAPL", horizon_days=3, predictions=[])
+
+    table_df = pd.DataFrame([{"date": "2026-04-15", "pred_close": 101.0}])
+    chart_df = pd.DataFrame({"pred_close": [101.0]}, index=pd.to_datetime(["2026-04-15"]))
+
+    monkeypatch.setattr(
+        predict_view.ForecastPresenter,
+        "format_predictions_table",
+        staticmethod(lambda _result: table_df),
+    )
+    monkeypatch.setattr(
+        predict_view.ForecastPresenter,
+        "format_price_chart_data",
+        staticmethod(lambda _result: chart_df),
+    )
+    monkeypatch.setattr(predict_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(predict_view.st, "subheader", lambda msg: events.append(("subheader", msg)))
+    monkeypatch.setattr(predict_view.st, "dataframe", lambda frame, **_kwargs: events.append(("dataframe", frame)))
+    monkeypatch.setattr(predict_view.st, "line_chart", lambda series, **_kwargs: events.append(("line_chart", series)))
+
+    predict_view._render_forecast(result)
+
+    assert ("subheader", "Forecast Results") in events
+    assert ("subheader", "Predicted Close Price") in events
+    assert any(kind == "dataframe" for kind, _ in events)
+    assert any(kind == "line_chart" for kind, _ in events)
+    assert not any(kind == "warning" for kind, _ in events)
+
+
+def test_predict_render_warns_when_no_prediction_models(monkeypatch) -> None:
+    events: list[tuple[str, str]] = []
+
+    model_defaults = SimpleNamespace(
+        id_to_label=lambda: {},
+        prediction_model_ids=lambda: (),
+        default_model_id="ridge",
+        horizon_min=1,
+        horizon_max=30,
+        default_horizon=7,
+    )
+    monkeypatch.setattr(
+        predict_view,
+        "_SETTINGS",
+        SimpleNamespace(
+            ticker_catalog=SimpleNamespace(entries=()),
+            model_defaults=model_defaults,
+        ),
+    )
+
+    monkeypatch.setattr(predict_view, "build_ticker_select_items", lambda _entries: [("AAPL", "AAPL")])
+    monkeypatch.setattr(predict_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "subheader", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(predict_view.st, "selectbox", lambda _label, options, **_kwargs: options[0])
+    monkeypatch.setattr(predict_view.st, "slider", lambda _label, **_kwargs: 7)
+
+    first_cols = (_ButtonCol(), _ButtonCol())
+    second_cols = (_ButtonCol({"Fetch Historical Data": False}), _ButtonCol({"Run Prediction": False}))
+    calls = {"n": 0}
+
+    def _columns(_n: int):
+        calls["n"] += 1
+        return first_cols if calls["n"] == 1 else second_cols
+
+    monkeypatch.setattr(predict_view.st, "columns", _columns)
+
+    predict_view.render()
+
+    assert ("warning", "No prediction-enabled models are configured.") in events
+
+
+def test_predict_render_executes_forecast_use_case_and_renders_result(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    model_defaults = SimpleNamespace(
+        id_to_label=lambda: {"ridge": "Ridge"},
+        prediction_model_ids=lambda: ("ridge",),
+        default_model_id="ridge",
+        horizon_min=1,
+        horizon_max=30,
+        default_horizon=7,
+    )
+    monkeypatch.setattr(
+        predict_view,
+        "_SETTINGS",
+        SimpleNamespace(
+            ticker_catalog=SimpleNamespace(entries=()),
+            model_defaults=model_defaults,
+        ),
+    )
+
+    monkeypatch.setattr(predict_view, "build_ticker_select_items", lambda _entries: [("AAPL", "AAPL")])
+    monkeypatch.setattr(predict_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "subheader", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "warning", lambda _msg: None)
+    monkeypatch.setattr(predict_view.st, "error", lambda msg: events.append(("error", msg)))
+    monkeypatch.setattr(predict_view.st, "selectbox", lambda _label, options, **_kwargs: options[0])
+    monkeypatch.setattr(predict_view.st, "slider", lambda _label, **_kwargs: 5)
+
+    first_cols = (_ButtonCol(), _ButtonCol())
+    second_cols = (_ButtonCol({"Fetch Historical Data": False}), _ButtonCol({"Run Prediction": True}))
+    calls = {"n": 0}
+
+    def _columns(_n: int):
+        calls["n"] += 1
+        return first_cols if calls["n"] == 1 else second_cols
+
+    monkeypatch.setattr(predict_view.st, "columns", _columns)
+
+    forecast_result = ForecastResult(model_id="ridge", ticker="AAPL", horizon_days=5, predictions=[])
+    monkeypatch.setattr(
+        predict_view,
+        "_forecast_uc",
+        lambda: SimpleNamespace(execute=lambda _req: forecast_result),
+    )
+    monkeypatch.setattr(
+        predict_view,
+        "_render_forecast",
+        lambda result: events.append(("render_forecast", result)),
+    )
+
+    predict_view.render()
+
+    assert any(kind == "render_forecast" for kind, _ in events)
+    assert not any(kind == "error" for kind, _ in events)
+
+


### PR DESCRIPTION
This pull request introduces a new presenters module to encapsulate display formatting logic for the Streamlit web UI, and refactors the codebase to use these presenters for rendering forecast and comparison results. The main improvements are the separation of formatting logic from view code for better testability and maintainability, as well as the addition of comprehensive unit tests for the new presenters.

**Introduction of presenter layer for UI formatting:**

* Added `src/finsight/adapters/web_streamlit/presenters.py` containing `ForecastPresenter` and `ComparisonPresenter` classes, which provide pure formatting functions to convert use-case outputs into DataFrames optimized for UI rendering. This layer does not contain any Streamlit calls, ensuring separation of concerns.

**Refactoring of views to use presenters:**

* Refactored `src/finsight/adapters/web_streamlit/views/compare.py` and `src/finsight/adapters/web_streamlit/views/predict.py` to delegate all DataFrame formatting to the appropriate presenter methods, removing in-place formatting logic from the views. 

**Testing improvements:**

* Added `tests/unit/adapters/web_streamlit/test_presenters.py` with thorough unit tests for both `ForecastPresenter` and `ComparisonPresenter`, covering normal and edge cases for all formatting methods.
* Updated existing tests in `tests/unit/adapters/web_streamlit/test_compare.py` to use the new presenter interface instead of the removed local formatting function. 

These changes improve code organization, testability, and maintainability by clearly separating formatting logic from UI rendering and ensuring correctness through unit tests.