### PR TITLE
Add CLI command for forecasting latest run by model ID

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -103,7 +103,12 @@ Thin presentation layer. Converts use case results into Streamlit widgets.
 
 ### `cli/`
 
-CLI entry point. Parses arguments and delegates to `TrainModel` and `CompareModels` via the container.
+CLI entry point. Parses arguments and delegates to use cases (`TrainModel`, `CompareModels`, `Forecast`) via the container.
+
+Supports three subcommands:
+- `train` — Execute model training and evaluation.
+- `compare` — Compare trained model runs and print a leaderboard.
+- `forecast` — Generate price forecasts from the latest run of a trained model.
 
 ---
 
@@ -161,6 +166,21 @@ Streamlit view
             └─ returns FetchMarketDataResult
 ```
 
+### Forecasting future prices
+
+```
+CLI / Streamlit view
+  └─ Forecast.execute(ForecastRequest)
+       ├─ ModelRegistryPort.latest_run_id              (locates latest run for model_id)
+       ├─ ModelRegistryPort.load_run_artifacts          (loads model, manifest, metrics)
+       ├─ FetchMarketData → MarketDataPort.fetch_ohlcv  (current market history)
+       ├─ FeatureStorePort.build_inference_feature_dataset
+       ├─ iteratively predict forward by horizon_days
+       │  ├─ model.predict(features)
+       │  └─ synthetic history row appended
+       └─ returns ForecastResult                        (date, pred_ret_1d, pred_close per row)
+```
+
 ---
 
 ## Extension Points
@@ -183,6 +203,17 @@ Streamlit view
 2. Implement the use case class in `application/use_cases/<name>.py`, depending only on
    domain ports.
 3. Add the use case to `AppContainer` in `bootstrap/container.py`.
+
+### Adding CLI commands
+
+1. Add a subparser in `_build_parser()` in `cli/main.py` with required/optional arguments.
+2. Implement a handler function `_run_<command>()` that:
+   - Builds the request DTO from parsed args.
+   - Calls the use case via `build_container()`.
+   - Renders output (text or JSON).
+   - Catches expected exceptions and maps them to clear stderr messages with non-zero exit codes.
+3. Add a dispatch route in `main()`.
+4. Add unit tests for parsing, delegation, output, and error paths.
 
 ---
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -1,0 +1,231 @@
+# CLI Usage Guide
+
+The FinSight CLI provides three main commands for training models, comparing runs, and generating forecasts.
+
+## Prerequisites
+
+1. **Install dependencies:**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Configure tickers and models** (optional):
+   Edit `config/config.yaml` to customize ticker catalog and model defaults.
+
+---
+
+## Commands
+
+### `train` — Train and evaluate models
+
+Trains baseline models on fixed tickers using historical market data.
+
+**Syntax:**
+```bash
+finsight train --cutoff CUTOFF_DATE [OPTIONS]
+```
+
+**Required Arguments:**
+- `--cutoff CUTOFF_DATE` — Global time-split cutoff date (ISO format: `YYYY-MM-DD`). Data before this date is training; after is testing.
+
+**Optional Arguments:**
+- `--years N` — Lookback window in years (default: `2`)
+- `--end END_DATE` — Inclusive end date for data fetch (default: today)
+- `--model-types TYPE [TYPE ...]` — Model IDs to train (default: all training-enabled models)
+- `--artifacts-dir DIR` — Directory for run artifacts (default: `artifacts/runs`)
+
+**Example:**
+```bash
+finsight train --cutoff 2025-06-01 --years 3 --model-types naive_zero ridge
+```
+
+**Output:**
+```
+[naive_zero] run_dir=artifacts/runs/2026-04-14T120000Z__naive_zero
+  MAE=0.015234 RMSE=0.018567 DirectionAcc=0.5432
+[ridge] run_dir=artifacts/runs/2026-04-14T120000Z__ridge
+  MAE=0.012456 RMSE=0.015678 DirectionAcc=0.6234
+```
+
+---
+
+### `compare` — Compare trained model runs
+
+Ranks trained models by performance metrics and prints a leaderboard.
+
+**Syntax:**
+```bash
+finsight compare [OPTIONS]
+```
+
+**Optional Arguments:**
+- `--model-ids ID [ID ...]` — Model IDs to compare (default: all training-enabled models)
+- `--rank-by METRIC [METRIC ...]` — Metrics for ranking (default: `mae rmse direction_accuracy`)
+- `--artifacts-dir DIR` — Directory containing model artifacts (default: `artifacts/runs`)
+
+**Available metrics:**
+- `mae` — Mean Absolute Error (lower is better)
+- `rmse` — Root Mean Squared Error (lower is better)
+- `direction_accuracy` — Proportion of correct direction predictions (higher is better)
+
+**Example:**
+```bash
+finsight compare --model-ids naive_zero ridge --rank-by mae direction_accuracy
+```
+
+**Output:**
+```
+rank                model        mae   rmse  direction_accuracy
+   1       Naive (Zero)  0.015234 0.0186              0.5432
+   2  Ridge Regression  0.012456 0.0157              0.6234
+```
+
+---
+
+### `forecast` — Generate price forecasts
+
+Forecasts future stock prices using the latest trained run of a specified model.
+
+**Syntax:**
+```bash
+finsight forecast --ticker TICKER --model-id MODEL_ID --horizon DAYS [OPTIONS]
+```
+
+**Required Arguments:**
+- `--ticker TICKER` — Stock ticker symbol (e.g., `AAPL`, `MSFT`)
+- `--model-id MODEL_ID` — Model ID to use for forecasting (e.g., `ridge`, `naive_zero`)
+- `--horizon DAYS` — Forecast horizon in trading days (must be positive integer)
+
+**Optional Arguments:**
+- `--artifacts-dir DIR` — Directory containing model artifacts (default: `artifacts/runs`)
+- `--json` — Output forecast as JSON (default: human-readable text)
+
+#### Text Output (default)
+
+**Example:**
+```bash
+finsight forecast --ticker AAPL --model-id ridge --horizon 5
+```
+
+**Output:**
+```
+[ridge] ticker=AAPL horizon_days=5 rows=5
+2026-04-15 pred_ret_1d=0.0125 pred_close=152.45
+2026-04-16 pred_ret_1d=-0.0087 pred_close=151.13
+2026-04-17 pred_ret_1d=0.0234 pred_close=154.68
+2026-04-20 pred_ret_1d=0.0056 pred_close=155.54
+2026-04-21 pred_ret_1d=-0.0045 pred_close=154.84
+```
+
+Fields:
+- `DATE` — Forecast date (ISO format: `YYYY-MM-DD`)
+- `pred_ret_1d` — Predicted 1-day return (decimal, e.g., 0.0125 = +1.25%)
+- `pred_close` — Predicted closing price
+
+#### JSON Output
+
+**Example:**
+```bash
+finsight forecast --ticker AAPL --model-id ridge --horizon 2 --json
+```
+
+**Output:**
+```json
+{
+  "generated_at": "2026-04-14T12:00:00Z",
+  "horizon_days": 2,
+  "model_id": "ridge",
+  "predictions": [
+    {
+      "date": "2026-04-15",
+      "pred_close": 152.45,
+      "pred_ret_1d": 0.0125
+    },
+    {
+      "date": "2026-04-16",
+      "pred_close": 151.13,
+      "pred_ret_1d": -0.0087
+    }
+  ],
+  "ticker": "AAPL"
+}
+```
+
+---
+
+## Error Handling
+
+All commands print errors to `stderr` and exit with code `1` on failure.
+
+### Common Error Scenarios
+
+#### Missing Required Arguments
+```bash
+$ finsight forecast --ticker AAPL
+usage: finsight forecast [-h] --ticker TICKER --model-id MODEL_ID --horizon HORIZON ...
+finsight forecast: error: the following arguments are required: --model-id, --horizon
+```
+
+#### Invalid Validation Inputs
+```bash
+$ finsight forecast --ticker "" --model-id ridge --horizon 5
+Forecast validation error: ticker must be a non-empty string.
+```
+
+```bash
+$ finsight forecast --ticker AAPL --model-id ridge --horizon 0
+Forecast validation error: horizon_days must be a positive integer.
+```
+
+#### No Trained Runs Found
+```bash
+$ finsight forecast --ticker AAPL --model-id unknown_model --horizon 5
+Forecast artifact error: No runs found for model_id 'unknown_model' under artifact root: artifacts/runs
+```
+
+**Solution:** Train the model first with `finsight train --cutoff <date>`.
+
+#### Corrupt or Incompatible Artifacts
+```bash
+$ finsight forecast --ticker AAPL --model-id ridge --horizon 5
+Forecast runtime error: Loaded model artifact does not implement predict(...).
+```
+
+**Solution:** Check that artifacts were saved correctly; retrain if necessary.
+
+---
+
+## Workflow Example
+
+A typical workflow from training to forecasting:
+
+```bash
+# 1. Train models with a cutoff date
+finsight train --cutoff 2025-06-01 --years 2 --model-types naive_zero ridge
+
+# 2. Compare the trained models to see which performed best
+finsight compare --model-ids naive_zero ridge --rank-by mae direction_accuracy
+
+# 3. Generate forecasts using the best model
+finsight forecast --ticker AAPL --model-id ridge --horizon 30
+
+# 4. Export forecast as JSON for downstream processing
+finsight forecast --ticker AAPL --model-id ridge --horizon 30 --json > forecast_aapl.json
+```
+
+---
+
+## Exit Codes
+
+- `0` — Success
+- `1` — Validation error, missing artifact, or runtime failure
+
+---
+
+## Notes
+
+- All dates must be in ISO format: `YYYY-MM-DD`.
+- Forecast dates skip weekends (business days only).
+- Predicted returns compound iteratively; each forecast feeds into the next day's feature engineering.
+- Use `--json` for scripting and automation; text output is optimized for human readability.
+

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -155,7 +155,7 @@ finsight forecast --ticker AAPL --model-id ridge --horizon 2 --json
 
 ## Error Handling
 
-All commands print errors to `stderr` and exit with code `1` on failure.
+All commands print errors to `stderr` on failure. Command-line usage and argument parsing errors exit with code `2`; validation errors, missing artifacts, and runtime failures exit with code `1`.
 
 ### Common Error Scenarios
 
@@ -219,6 +219,7 @@ finsight forecast --ticker AAPL --model-id ridge --horizon 30 --json > forecast_
 
 - `0` — Success
 - `1` — Validation error, missing artifact, or runtime failure
+- `2` — Command-line usage or argument parsing error (for example, missing required arguments)
 
 ---
 

--- a/src/finsight/cli/main.py
+++ b/src/finsight/cli/main.py
@@ -147,15 +147,15 @@ def _run_compare(args: argparse.Namespace) -> int:
     return 0
 
 
-def _run_forecast(_args: argparse.Namespace) -> int:
+def _run_forecast(args: argparse.Namespace) -> int:
     try:
         container = build_container()
         response = container.forecast.execute(
             ForecastRequest(
-                ticker=_args.ticker,
-                model_id=_args.model_id,
-                horizon_days=_args.horizon,
-                artifacts_dir=_args.artifacts_dir,
+                ticker=args.ticker,
+                model_id=args.model_id,
+                horizon_days=args.horizon,
+                artifacts_dir=args.artifacts_dir,
             )
         )
     except ValueError as exc:
@@ -171,7 +171,7 @@ def _run_forecast(_args: argparse.Namespace) -> int:
         print(f"Forecast unexpected error: {exc}", file=sys.stderr)
         return 1
 
-    if _args.as_json:
+    if args.as_json:
         print(json.dumps(response.to_dict(), indent=2, sort_keys=True))
         return 0
 

--- a/src/finsight/cli/main.py
+++ b/src/finsight/cli/main.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import argparse
+import json
+import sys
 
 import pandas as pd
 
-from finsight.application.dto import CompareModelsRequest, TrainModelRequest
+from finsight.application.dto import CompareModelsRequest, ForecastRequest, TrainModelRequest
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
 from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
@@ -60,6 +62,25 @@ def _build_parser() -> argparse.ArgumentParser:
         "--artifacts-dir",
         default="artifacts/runs",
         help="Directory containing model run artifacts",
+    )
+
+    forecast_parser = subparsers.add_parser(
+        "forecast",
+        help="Forecast future prices from the latest trained run for a model",
+    )
+    forecast_parser.add_argument("--ticker", required=True, help="Ticker symbol to forecast (e.g. AAPL)")
+    forecast_parser.add_argument("--model-id", required=True, help="Model ID to use for selecting the latest run")
+    forecast_parser.add_argument("--horizon", type=int, required=True, help="Forecast horizon in trading days")
+    forecast_parser.add_argument(
+        "--artifacts-dir",
+        default="artifacts/runs",
+        help="Directory containing model run artifacts",
+    )
+    forecast_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Print forecast response as JSON",
     )
 
     return parser
@@ -126,6 +147,50 @@ def _run_compare(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_forecast(_args: argparse.Namespace) -> int:
+    try:
+        container = build_container()
+        response = container.forecast.execute(
+            ForecastRequest(
+                ticker=_args.ticker,
+                model_id=_args.model_id,
+                horizon_days=_args.horizon,
+                artifacts_dir=_args.artifacts_dir,
+            )
+        )
+    except ValueError as exc:
+        print(f"Forecast validation error: {exc}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(f"Forecast artifact error: {exc}", file=sys.stderr)
+        return 1
+    except TypeError as exc:
+        print(f"Forecast runtime error: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Forecast unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+    if _args.as_json:
+        print(json.dumps(response.to_dict(), indent=2, sort_keys=True))
+        return 0
+
+    print(
+        f"[{response.model_id}] ticker={response.ticker} "
+        f"horizon_days={response.horizon_days} rows={len(response.predictions)}"
+    )
+    for row in response.predictions:
+        date_value = row.get("date", "")
+        pred_ret_value = row.get("pred_ret_1d")
+        pred_close_value = row.get("pred_close")
+        print(
+            f"{date_value} "
+            f"pred_ret_1d={pred_ret_value} "
+            f"pred_close={pred_close_value}"
+        )
+    return 0
+
+
 def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
@@ -135,6 +200,9 @@ def main() -> int:
 
     if args.command == "compare":
         return _run_compare(args)
+
+    if args.command == "forecast":
+        return _run_forecast(args)
 
     parser.error(f"Unknown command: {args.command}")
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,8 +1,9 @@
 import pytest
+import json
 
 import finsight.cli.main as cli_main
 from finsight.cli.main import _build_parser, _run_train
-from finsight.application.dto import CompareModelsResult, ModelComparisonRow
+from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow
 from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
 from finsight.config.settings import ModelCatalogEntry, ModelDefaults, Settings, TickerCatalogSettings
 
@@ -40,6 +41,202 @@ def test_compare_parser_accepts_compare_model_ids_and_rank_by() -> None:
     assert args.command == "compare"
     assert args.model_ids == ["naive_zero", "ridge"]
     assert args.rank_by == ["mae", "direction_accuracy"]
+
+
+def test_forecast_parser_accepts_required_args() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "30"])
+
+    assert args.command == "forecast"
+    assert args.ticker == "AAPL"
+    assert args.model_id == "ridge"
+    assert args.horizon == 30
+    assert args.artifacts_dir == "artifacts/runs"
+    assert args.as_json is False
+
+
+def test_forecast_parser_accepts_json_flag() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "30", "--json"])
+
+    assert args.as_json is True
+
+
+def test_main_dispatches_forecast_command_to_run_forecast(monkeypatch) -> None:
+    monkeypatch.setattr(cli_main, "_run_forecast", lambda _args: 7)
+    monkeypatch.setattr("sys.argv", ["finsight", "forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "5"])
+
+    assert cli_main.main() == 7
+
+
+def test_run_forecast_prints_prediction_rows(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        last_request = None
+
+        @classmethod
+        def execute(cls, request):
+            cls.last_request = request
+            return ForecastResult(
+                model_id="ridge",
+                ticker="AAPL",
+                horizon_days=2,
+                predictions=[
+                    {"date": "2026-04-13", "pred_ret_1d": 0.1, "pred_close": 119.9},
+                    {"date": "2026-04-14", "pred_ret_1d": -0.05, "pred_close": 113.905},
+                ],
+                generated_at="2026-04-12T12:00:00Z",
+            )
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "2"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured = capsys.readouterr().out
+    assert exit_code == 0
+    assert _StubForecast.last_request.ticker == "AAPL"
+    assert _StubForecast.last_request.model_id == "ridge"
+    assert _StubForecast.last_request.horizon_days == 2
+    assert _StubForecast.last_request.artifacts_dir == "artifacts/runs"
+    assert "[ridge] ticker=AAPL horizon_days=2 rows=2" in captured
+    assert "2026-04-13 pred_ret_1d=0.1 pred_close=119.9" in captured
+    assert "2026-04-14 pred_ret_1d=-0.05 pred_close=113.905" in captured
+
+
+def test_run_forecast_prints_json_when_requested(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        @staticmethod
+        def execute(_request):
+            return ForecastResult(
+                model_id="ridge",
+                ticker="AAPL",
+                horizon_days=1,
+                predictions=[{"date": "2026-04-13", "pred_ret_1d": 0.1, "pred_close": 119.9}],
+                generated_at="2026-04-12T12:00:00Z",
+            )
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "1", "--json"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+
+    assert exit_code == 0
+    assert payload["model_id"] == "ridge"
+    assert payload["ticker"] == "AAPL"
+    assert payload["horizon_days"] == 1
+    assert payload["predictions"][0]["pred_ret_1d"] == 0.1
+    assert payload["predictions"][0]["pred_close"] == 119.9
+
+
+def test_run_forecast_handles_empty_ticker_validation_error(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        @staticmethod
+        def execute(_request):
+            raise ValueError("ticker must be a non-empty string.")
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "", "--model-id", "ridge", "--horizon", "5"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured_err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "Forecast validation error" in captured_err
+    assert "ticker must be a non-empty string" in captured_err
+
+
+def test_run_forecast_handles_invalid_horizon_validation_error(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        @staticmethod
+        def execute(_request):
+            raise ValueError("horizon_days must be a positive integer.")
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "0"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured_err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "Forecast validation error" in captured_err
+    assert "horizon_days must be a positive integer" in captured_err
+
+
+def test_run_forecast_handles_missing_run_file_not_found_error(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        @staticmethod
+        def execute(_request):
+            raise FileNotFoundError("No runs found for model_id 'unknown_model' under artifact root: artifacts/runs")
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "AAPL", "--model-id", "unknown_model", "--horizon", "5"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured_err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "Forecast artifact error" in captured_err
+    assert "No runs found for model_id" in captured_err
+
+
+def test_run_forecast_handles_model_type_error(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        @staticmethod
+        def execute(_request):
+            raise TypeError("Loaded model artifact does not implement predict(...).")
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "5"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured_err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "Forecast runtime error" in captured_err
+    assert "does not implement predict" in captured_err
+
+
+def test_run_forecast_handles_unexpected_exception(monkeypatch, capsys) -> None:
+    class _StubForecast:
+        @staticmethod
+        def execute(_request):
+            raise RuntimeError("Unexpected internal error occurred.")
+
+    class _StubContainer:
+        forecast = _StubForecast()
+
+    monkeypatch.setattr(cli_main, "build_container", lambda: _StubContainer())
+
+    args = _build_parser().parse_args(["forecast", "--ticker", "AAPL", "--model-id", "ridge", "--horizon", "5"])
+    exit_code = cli_main._run_forecast(args)
+
+    captured_err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "Forecast unexpected error" in captured_err
+    assert "Unexpected internal error occurred" in captured_err
 
 
 def test_run_train_prints_metrics_using_canonical_metric_keys(monkeypatch, capsys) -> None:


### PR DESCRIPTION
This pull request introduces a new `forecast` CLI command for generating price forecasts using the latest trained model run, along with comprehensive documentation and robust test coverage. The main changes include extending the CLI interface, implementing command dispatch and error handling, updating the architecture and usage documentation, and adding unit tests for the new functionality.

**CLI Enhancements:**

* Added a new `forecast` subcommand to the CLI, supporting arguments for ticker, model ID, forecast horizon, artifact directory, and JSON output. This command executes the `Forecast` use case and prints predictions in either human-readable or JSON format. 

**Documentation Updates:**

* Updated `docs/architecture/overview.md` to describe the new `forecast` command, its use case flow, and how to extend the CLI with new commands. 
* Added a new `docs/cli-usage.md` guide detailing CLI installation, command syntax, argument descriptions, output examples, error handling, and workflow examples for training, comparing, and forecasting.

**Testing Improvements:**

* Added extensive unit tests for the `forecast` command, covering argument parsing, command dispatch, output formatting (text and JSON), and error handling for validation, missing artifacts, and runtime failures.

**Internal Refactoring:**

* Updated imports and DTO usage to support the new `ForecastRequest` and `ForecastResult` types in the CLI. 

These changes collectively provide a robust and user-friendly CLI interface for price forecasting, with clear documentation and high test coverage.