### PR TITLE
Chore/issues/47 add non linear sklearn regressor adapter hist gbdt and wire into model router

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,10 @@ model_defaults:
       label: "Ridge Regression"
       supports_training: true
       supports_prediction: true
+    - id: "hist_gbdt"
+      label: "Histogram Gradient Boosting"
+      supports_training: true
+      supports_prediction: true
   default_model_id: "naive_zero"
   horizon_min: 7
   horizon_max: 90

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -73,7 +73,10 @@ Provides concrete implementations of the domain ports.
 |---|---|
 | `market_data/yfinance_provider.py` | `MarketDataPort` |
 | `features/feature_store.py` | `FeatureStorePort` |
-| `ml/sklearn/baseline.py` | `ModelPort` |
+| `ml/sklearn/router.py` | `ModelPort` (routes model IDs to concrete sklearn adapters) |
+| `ml/sklearn/baseline.py` | `ModelPort` (`naive_zero`, `naive_mean`) |
+| `ml/sklearn/linear.py` | `ModelPort` (`ridge`) |
+| `ml/sklearn/tree.py` | `ModelPort` (`hist_gbdt`) |
 | `ml/registry.py` | `ModelRegistryPort` |
 
 **Rules:**

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -155,16 +155,17 @@ finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 2 --json
   "ticker": "AAPL"
 }
 ```
-finsight train --cutoff 2025-06-01 --years 2 --model-types naive_zero ridge hist_gbdt
+
 ---
 
-finsight compare --model-ids naive_zero ridge hist_gbdt --rank-by mae direction_accuracy
+## Error Handling
 
 All commands print errors to `stderr` on failure. Command-line usage and argument parsing errors exit with code `2`; validation errors, missing artifacts, and runtime failures exit with code `1`.
-finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 30
+
 ### Common Error Scenarios
 
-finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 30 --json > forecast_aapl.json
+#### Missing Required Arguments
+
 ```bash
 $ finsight forecast --ticker AAPL
 usage: finsight forecast [-h] --ticker TICKER --model-id MODEL_ID --horizon HORIZON ...

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -18,7 +18,7 @@ The FinSight CLI provides three main commands for training models, comparing run
 
 ### `train` — Train and evaluate models
 
-Trains baseline models on historical market data and writes the artifacts that power the web app's training/backtesting view.
+Trains configured models on historical market data and writes the artifacts that power the web app's training/backtesting view.
 
 **Syntax:**
 ```bash
@@ -31,12 +31,12 @@ finsight train --cutoff CUTOFF_DATE [OPTIONS]
 **Optional Arguments:**
 - `--years N` — Lookback window in years (default: `2`)
 - `--end END_DATE` — Inclusive end date for data fetch (default: today)
-- `--model-types TYPE [TYPE ...]` — Model IDs to train (default: all training-enabled models)
+- `--model-types TYPE [TYPE ...]` — Model IDs to train (default: all training-enabled models, e.g. `naive_zero`, `naive_mean`, `ridge`, `hist_gbdt`)
 - `--artifacts-dir DIR` — Directory for run artifacts (default: `artifacts/runs`)
 
 **Example:**
 ```bash
-finsight train --cutoff 2025-06-01 --years 3 --model-types naive_zero ridge
+finsight train --cutoff 2025-06-01 --years 3 --model-types naive_zero ridge hist_gbdt
 ```
 
 **Output:**
@@ -45,6 +45,8 @@ finsight train --cutoff 2025-06-01 --years 3 --model-types naive_zero ridge
   MAE=0.015234 RMSE=0.018567 DirectionAcc=0.5432
 [ridge] run_dir=artifacts/runs/2026-04-14T120000Z__ridge
   MAE=0.012456 RMSE=0.015678 DirectionAcc=0.6234
+[hist_gbdt] run_dir=artifacts/runs/2026-04-14T120000Z__hist_gbdt
+  MAE=0.011982 RMSE=0.015201 DirectionAcc=0.6310
 ```
 
 The Streamlit `Train & Backtest` page uses the same underlying training use case, then renders chart-ready backtest outputs by ticker and model.
@@ -72,14 +74,15 @@ finsight compare [OPTIONS]
 
 **Example:**
 ```bash
-finsight compare --model-ids naive_zero ridge --rank-by mae direction_accuracy
+finsight compare --model-ids naive_zero ridge hist_gbdt --rank-by mae direction_accuracy
 ```
 
 **Output:**
 ```
 rank                model        mae    rmse  direction_accuracy
-   1     Ridge Regression   0.012456  0.0157              0.6234
-   2         Naive (Zero)   0.015234  0.0186              0.5432
+   1  Histogram Gradient Boosting   0.011982  0.0152              0.6310
+   2           Ridge Regression    0.012456  0.0157              0.6234
+   3               Naive (Zero)    0.015234  0.0186              0.5432
 ```
 
 ---
@@ -95,7 +98,7 @@ finsight forecast --ticker TICKER --model-id MODEL_ID --horizon DAYS [OPTIONS]
 
 **Required Arguments:**
 - `--ticker TICKER` — Stock ticker symbol (e.g., `AAPL`, `MSFT`)
-- `--model-id MODEL_ID` — Model ID to use for forecasting (e.g., `ridge`, `naive_zero`)
+- `--model-id MODEL_ID` — Model ID to use for forecasting (e.g., `hist_gbdt`, `ridge`, `naive_zero`)
 - `--horizon DAYS` — Forecast horizon in trading days (must be positive integer)
 
 **Optional Arguments:**
@@ -106,12 +109,12 @@ finsight forecast --ticker TICKER --model-id MODEL_ID --horizon DAYS [OPTIONS]
 
 **Example:**
 ```bash
-finsight forecast --ticker AAPL --model-id ridge --horizon 5
+finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 5
 ```
 
 **Output:**
 ```
-[ridge] ticker=AAPL horizon_days=5 rows=5
+[hist_gbdt] ticker=AAPL horizon_days=5 rows=5
 2026-04-15 pred_ret_1d=0.0125 pred_close=152.45
 2026-04-16 pred_ret_1d=-0.0087 pred_close=151.13
 2026-04-17 pred_ret_1d=0.0234 pred_close=154.68
@@ -128,7 +131,7 @@ Fields:
 
 **Example:**
 ```bash
-finsight forecast --ticker AAPL --model-id ridge --horizon 2 --json
+finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 2 --json
 ```
 
 **Output:**
@@ -136,7 +139,7 @@ finsight forecast --ticker AAPL --model-id ridge --horizon 2 --json
 {
   "generated_at": "2026-04-14T12:00:00Z",
   "horizon_days": 2,
-  "model_id": "ridge",
+  "model_id": "hist_gbdt",
   "predictions": [
     {
       "date": "2026-04-15",
@@ -152,16 +155,16 @@ finsight forecast --ticker AAPL --model-id ridge --horizon 2 --json
   "ticker": "AAPL"
 }
 ```
-
+finsight train --cutoff 2025-06-01 --years 2 --model-types naive_zero ridge hist_gbdt
 ---
 
-## Error Handling
+finsight compare --model-ids naive_zero ridge hist_gbdt --rank-by mae direction_accuracy
 
 All commands print errors to `stderr` on failure. Command-line usage and argument parsing errors exit with code `2`; validation errors, missing artifacts, and runtime failures exit with code `1`.
-
+finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 30
 ### Common Error Scenarios
 
-#### Missing Required Arguments
+finsight forecast --ticker AAPL --model-id hist_gbdt --horizon 30 --json > forecast_aapl.json
 ```bash
 $ finsight forecast --ticker AAPL
 usage: finsight forecast [-h] --ticker TICKER --model-id MODEL_ID --horizon HORIZON ...

--- a/src/finsight/bootstrap/container.py
+++ b/src/finsight/bootstrap/container.py
@@ -10,7 +10,7 @@ from finsight.application.use_cases.train_model import TrainModel
 from finsight.config.settings import get_settings
 from finsight.infrastructure.features.feature_store import PandasFeatureStore
 from finsight.infrastructure.market_data.yfinance_provider import YFinanceMarketDataProvider
-from finsight.infrastructure.ml.sklearn import LinearSklearnModel, NaiveBaselineModel, SklearnModelRouter
+from finsight.infrastructure.ml.sklearn import HistGradientBoostingModel, LinearSklearnModel, NaiveBaselineModel, SklearnModelRouter
 from finsight.infrastructure.ml.registry import LocalFileModelRegistry
 
 
@@ -37,7 +37,11 @@ def build_container() -> AppContainer:
     )
 
     feature_store = PandasFeatureStore()
-    model = SklearnModelRouter(adapters=[NaiveBaselineModel(), LinearSklearnModel()])
+    model = SklearnModelRouter(adapters=[
+        NaiveBaselineModel(),
+        LinearSklearnModel(),
+        HistGradientBoostingModel(),
+    ])
     model_registry = LocalFileModelRegistry()
     train_model = TrainModel(
         fetch_market_data=fetch_market_data,

--- a/src/finsight/infrastructure/ml/sklearn/__init__.py
+++ b/src/finsight/infrastructure/ml/sklearn/__init__.py
@@ -1,6 +1,7 @@
 from finsight.infrastructure.ml.sklearn.baseline import NaiveBaselineModel
 from finsight.infrastructure.ml.sklearn.linear import LinearSklearnModel
+from finsight.infrastructure.ml.sklearn.tree import HistGradientBoostingModel
 from finsight.infrastructure.ml.sklearn.router import SklearnModelRouter
 
-__all__ = ["NaiveBaselineModel", "LinearSklearnModel", "SklearnModelRouter"]
+__all__ = ["NaiveBaselineModel", "LinearSklearnModel", "HistGradientBoostingModel", "SklearnModelRouter"]
 

--- a/src/finsight/infrastructure/ml/sklearn/tree.py
+++ b/src/finsight/infrastructure/ml/sklearn/tree.py
@@ -4,8 +4,6 @@ from typing import Sequence
 
 import pandas as pd
 from sklearn.ensemble import HistGradientBoostingRegressor
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import StandardScaler
 from sklearn.inspection import permutation_importance
 
 from finsight.domain.entities import ModelEvaluationResult
@@ -52,27 +50,31 @@ class HistGradientBoostingModel(ModelPort):
         y_test = test_df[target_column].to_numpy(dtype=float)
 
         # Hyperparameters for HistGradientBoostingRegressor
-        learning_rate = 0.1
-        max_iter = 100
-        max_depth = 5
+        learning_rate = 0.03
+        max_iter = 200
+        max_depth = 2
+        min_samples_leaf = 20
+        l2_regularization = 1.0
 
-        model = Pipeline([
-            ("scaler", StandardScaler()),
-            ("hist_gbdt", HistGradientBoostingRegressor(
-                learning_rate=learning_rate,
-                max_iter=max_iter,
-                max_depth=max_depth,
-                random_state=RANDOM_STATE,
-            )),
-        ])
+        model = HistGradientBoostingRegressor(
+            learning_rate=learning_rate,
+            max_iter=max_iter,
+            max_depth=max_depth,
+            random_state=RANDOM_STATE,
+            min_samples_leaf=min_samples_leaf,
+            l2_regularization=l2_regularization,
+        )
         model.fit(x_train, y_train)
         y_pred = model.predict(x_test)
-        hist_gbdt_model = model.named_steps["hist_gbdt"]
+        hist_gbdt_model = model
 
         # Compute feature importances (if available)
         try:
-            importances = hist_gbdt_model.feature_importances_
-            feature_importance = self._feature_importance_ranking(feature_columns, importances)
+            importances = getattr(hist_gbdt_model, "feature_importances_", None)
+            if importances is not None:
+                feature_importance = self._feature_importance_ranking(feature_columns, importances)
+            else:
+                raise AttributeError
         except AttributeError:
             # Fallback: use permutation importance if direct importance is unavailable
             perm_importance = permutation_importance(
@@ -104,9 +106,11 @@ class HistGradientBoostingModel(ModelPort):
                     "learning_rate": learning_rate,
                     "max_iter": max_iter,
                     "max_depth": max_depth,
+                    "min_samples_leaf": min_samples_leaf,
+                    "l2_regularization": l2_regularization,
                     "random_state": RANDOM_STATE,
                 },
-                "preprocessing": {"scaler": "StandardScaler"},
+                "preprocessing": {},
                 "feature_importance": {item["feature"]: item["importance"] for item in feature_importance},
                 "feature_importance_ranking": feature_importance,
             },

--- a/src/finsight/infrastructure/ml/sklearn/tree.py
+++ b/src/finsight/infrastructure/ml/sklearn/tree.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.inspection import permutation_importance
+
+from finsight.domain.entities import ModelEvaluationResult
+from finsight.domain.metrics import forecast_metrics
+from finsight.domain.ports import ModelPort
+
+SUPPORTED_MODEL_TYPES = ("hist_gbdt",)
+RANDOM_STATE = 42
+
+
+class HistGradientBoostingModel(ModelPort):
+    """Tree-based gradient boosting regressor adapter."""
+
+    def evaluate(
+        self,
+        *,
+        train_dataset: object,
+        test_dataset: object,
+        model_type: str,
+        target_column: str,
+        id_columns: Sequence[str] = ("date", "ticker"),
+    ) -> ModelEvaluationResult:
+        train_df = self._require_dataframe(train_dataset, arg_name="train_dataset")
+        test_df = self._require_dataframe(test_dataset, arg_name="test_dataset")
+
+        if model_type not in SUPPORTED_MODEL_TYPES:
+            raise ValueError(
+                f"Unsupported model type '{model_type}'. Supported model types: {SUPPORTED_MODEL_TYPES}."
+            )
+
+        if target_column not in train_df.columns or target_column not in test_df.columns:
+            raise ValueError(f"Both train_df and test_df must contain '{target_column}'.")
+
+        if train_df.empty or test_df.empty:
+            raise ValueError("train_df and test_df must be non-empty for evaluation.")
+
+        feature_columns = self._feature_columns(train_df, test_df, target_column=target_column, id_columns=id_columns)
+        if not feature_columns:
+            raise ValueError("No numeric feature columns available for histogram gradient boosting model evaluation.")
+
+        x_train = train_df.loc[:, feature_columns].to_numpy(dtype=float)
+        x_test = test_df.loc[:, feature_columns].to_numpy(dtype=float)
+        y_train = train_df[target_column].to_numpy(dtype=float)
+        y_test = test_df[target_column].to_numpy(dtype=float)
+
+        # Hyperparameters for HistGradientBoostingRegressor
+        learning_rate = 0.1
+        max_iter = 100
+        max_depth = 5
+
+        model = Pipeline([
+            ("scaler", StandardScaler()),
+            ("hist_gbdt", HistGradientBoostingRegressor(
+                learning_rate=learning_rate,
+                max_iter=max_iter,
+                max_depth=max_depth,
+                random_state=RANDOM_STATE,
+            )),
+        ])
+        model.fit(x_train, y_train)
+        y_pred = model.predict(x_test)
+        hist_gbdt_model = model.named_steps["hist_gbdt"]
+
+        # Compute feature importances (if available)
+        try:
+            importances = hist_gbdt_model.feature_importances_
+            feature_importance = self._feature_importance_ranking(feature_columns, importances)
+        except AttributeError:
+            # Fallback: use permutation importance if direct importance is unavailable
+            perm_importance = permutation_importance(
+                model, x_test, y_test, n_repeats=10, random_state=RANDOM_STATE, n_jobs=-1
+            )
+            feature_importance = self._feature_importance_ranking(
+                feature_columns, perm_importance.importances_mean
+            )
+
+        metrics = forecast_metrics(y_true=y_test.tolist(), y_pred=y_pred.tolist())
+
+        pred_cols = [col for col in id_columns if col in test_df.columns]
+        predictions = test_df[pred_cols].copy() if pred_cols else pd.DataFrame(index=test_df.index)
+        predictions["y_true"] = y_test
+        predictions["y_pred"] = y_pred
+
+        return ModelEvaluationResult(
+            metrics=metrics,
+            predictions=predictions.reset_index(drop=True),
+            trained_artifact=model,
+            model_metadata={
+                "adapter": "HistGradientBoostingModel",
+                "model_id": model_type,
+                "estimator": model.__class__.__name__,
+                "base_estimator": hist_gbdt_model.__class__.__name__,
+                "feature_columns": feature_columns,
+                "n_features": len(feature_columns),
+                "hyperparams": {
+                    "learning_rate": learning_rate,
+                    "max_iter": max_iter,
+                    "max_depth": max_depth,
+                    "random_state": RANDOM_STATE,
+                },
+                "preprocessing": {"scaler": "StandardScaler"},
+                "feature_importance": {item["feature"]: item["importance"] for item in feature_importance},
+                "feature_importance_ranking": feature_importance,
+            },
+        )
+
+    def supported_model_types(self) -> tuple[str, ...]:
+        return SUPPORTED_MODEL_TYPES
+
+    @staticmethod
+    def _feature_columns(
+        train_df: pd.DataFrame,
+        test_df: pd.DataFrame,
+        *,
+        target_column: str,
+        id_columns: Sequence[str],
+    ) -> list[str]:
+        excluded = {target_column, *id_columns}
+        common = [col for col in train_df.columns if col in test_df.columns and col not in excluded]
+        numeric = [
+            col
+            for col in common
+            if pd.api.types.is_numeric_dtype(train_df[col])
+            and pd.api.types.is_numeric_dtype(test_df[col])
+        ]
+        return numeric
+
+    @staticmethod
+    def _require_dataframe(dataset: object, *, arg_name: str) -> pd.DataFrame:
+        if not isinstance(dataset, pd.DataFrame):
+            raise TypeError(f"{arg_name} must be a pandas DataFrame.")
+        return dataset
+
+    @staticmethod
+    def _feature_importance_ranking(
+        feature_columns: list[str], importances: object
+    ) -> list[dict[str, float | str]]:
+        importance_series = pd.Series(importances, index=feature_columns, dtype=float)
+        ranking = importance_series.sort_values(ascending=False)
+        return [
+            {
+                "feature": str(feature),
+                "importance": float(importance_series.loc[feature]),
+                "rank": int(idx + 1),
+            }
+            for idx, (feature, _) in enumerate(ranking.items())
+        ]
+
+

--- a/tests/integration/test_hist_gbdt_e2e.py
+++ b/tests/integration/test_hist_gbdt_e2e.py
@@ -1,0 +1,312 @@
+"""End-to-end integration tests for HistGradientBoostingModel (hist_gbdt)."""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from typing import cast
+
+import pandas as pd
+import pytest
+
+from finsight.application.dto import FetchMarketDataRequest, ForecastRequest, TrainModelRequest
+from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.application.use_cases.forecast import Forecast
+from finsight.application.use_cases.train_model import TrainModel
+from finsight.domain.entities import OHLCVSeries
+from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
+from finsight.domain.value_objects import DateRange, Interval, Ticker
+from finsight.infrastructure.features.feature_store import PandasFeatureStore
+from finsight.infrastructure.ml.registry import LocalFileModelRegistry
+from finsight.infrastructure.ml.sklearn import HistGradientBoostingModel, NaiveBaselineModel, SklearnModelRouter
+
+
+class _StubFetchMarketData:
+    """Stub market data provider that returns synthetic OHLCV data."""
+
+    def __init__(self, data_by_ticker: dict[str, OHLCVSeries]) -> None:
+        self.data_by_ticker = data_by_ticker
+        self.calls: list[FetchMarketDataRequest] = []
+
+    def execute(self, request: FetchMarketDataRequest) -> object:
+        self.calls.append(request)
+        ticker = request.ticker
+        if ticker not in self.data_by_ticker:
+            raise ValueError(f"No data for ticker {ticker}")
+        return SimpleNamespace(history=self.data_by_ticker[ticker])
+
+
+def _make_synthetic_ohlcv_series(ticker: str) -> OHLCVSeries:
+    """Create a synthetic OHLCV series with features for model training."""
+    dates = pd.date_range("2023-01-01", "2024-12-31", freq="D")
+    close = [100.0 + (idx * 0.25) for idx in range(len(dates))]
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": close,
+            "High": close,
+            "Low": close,
+            "Close": close,
+            "Volume": [1000 + idx for idx in range(len(dates))],
+        }
+    )
+
+    return OHLCVSeries(
+        ticker=Ticker(ticker),
+        date_range=DateRange(start=dates[0].date().isoformat(), end=dates[-1].date().isoformat()),
+        interval=Interval("1d"),
+        df=df,
+    )
+
+
+def test_hist_gbdt_training_end_to_end() -> None:
+    """Verify hist_gbdt can train, evaluate, and save artifacts."""
+    with TemporaryDirectory() as tmp_dir:
+        # Setup
+        tickers = ("AAPL",)
+        data = {ticker: _make_synthetic_ohlcv_series(ticker) for ticker in tickers}
+        stub_market_data = _StubFetchMarketData(data)
+
+        train_model = TrainModel(
+            fetch_market_data=cast(FetchMarketData, stub_market_data),
+            feature_store=PandasFeatureStore(),
+            model=SklearnModelRouter(adapters=[
+                NaiveBaselineModel(),
+                HistGradientBoostingModel(),
+            ]),
+            model_registry=LocalFileModelRegistry(),
+            training_tickers=tickers,
+            supported_model_types=("hist_gbdt",),
+        )
+
+        # Execute
+        request = TrainModelRequest(
+            cutoff_date="2024-06-01",
+            years=1,
+            end="2024-12-31",
+            model_types=["hist_gbdt"],
+            artifacts_dir=tmp_dir,
+        )
+        result = train_model.execute(request)
+
+        # Verify
+        assert "hist_gbdt" in result.run_dirs
+        assert isinstance(result.run_dirs["hist_gbdt"], str)
+
+        run_dir = result.run_dirs["hist_gbdt"]
+        assert Path(run_dir).exists()
+
+        # Verify metrics
+        assert "hist_gbdt" in result.metrics
+        metrics = result.metrics["hist_gbdt"]
+        assert set(SUPPORTED_METRIC_NAMES).issubset(metrics)
+
+        # Verify artifacts exist
+        assert (Path(run_dir) / "metrics.json").exists()
+        assert (Path(run_dir) / "manifest.json").exists()
+        assert (Path(run_dir) / "predictions.csv").exists()
+
+        # Verify manifest content
+        manifest_path = Path(run_dir) / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["model_id"] == "hist_gbdt"
+        assert manifest["params"]["model_metadata"]["model_id"] == "hist_gbdt"
+        assert manifest["params"]["model_metadata"]["base_estimator"] == "HistGradientBoostingRegressor"
+
+        # Verify predictions
+        predictions_path = Path(run_dir) / "predictions.csv"
+        predictions_df = pd.read_csv(predictions_path)
+        assert "date" in predictions_df.columns
+        assert "ticker" in predictions_df.columns
+        assert "y_true" in predictions_df.columns
+        assert "y_pred" in predictions_df.columns
+        assert len(predictions_df) > 0
+
+
+def test_hist_gbdt_training_with_multiple_models() -> None:
+    """Verify hist_gbdt trains alongside other models."""
+    with TemporaryDirectory() as tmp_dir:
+        # Setup
+        tickers = ("AAPL",)
+        data = {ticker: _make_synthetic_ohlcv_series(ticker) for ticker in tickers}
+        stub_market_data = _StubFetchMarketData(data)
+
+        train_model = TrainModel(
+            fetch_market_data=cast(FetchMarketData, stub_market_data),
+            feature_store=PandasFeatureStore(),
+            model=SklearnModelRouter(adapters=[
+                NaiveBaselineModel(),
+                HistGradientBoostingModel(),
+            ]),
+            model_registry=LocalFileModelRegistry(),
+            training_tickers=tickers,
+            supported_model_types=("naive_zero", "hist_gbdt"),
+        )
+
+        # Execute: train both naive_zero and hist_gbdt
+        request = TrainModelRequest(
+            cutoff_date="2024-06-01",
+            years=1,
+            end="2024-12-31",
+            model_types=["naive_zero", "hist_gbdt"],
+            artifacts_dir=tmp_dir,
+        )
+        result = train_model.execute(request)
+
+        # Verify both models trained
+        assert "naive_zero" in result.run_dirs
+        assert "hist_gbdt" in result.run_dirs
+
+        # Verify both have metrics
+        assert "naive_zero" in result.metrics
+        assert "hist_gbdt" in result.metrics
+
+
+def test_hist_gbdt_deterministic_predictions() -> None:
+    """Verify hist_gbdt produces identical predictions on same data."""
+    with TemporaryDirectory() as tmp_dir_1, TemporaryDirectory() as tmp_dir_2:
+        from finsight.config.settings import get_settings
+        from finsight.bootstrap.container import build_container
+
+        # Build container to get properly configured training (respecting config.yaml)
+        build_container.cache_clear()
+        container = build_container()
+        settings = get_settings()
+
+        tickers = ("AAPL",)
+        data = {ticker: _make_synthetic_ohlcv_series(ticker) for ticker in tickers}
+
+        # Train 1
+        stub_market_data_1 = _StubFetchMarketData(data)
+        train_model_1 = TrainModel(
+            fetch_market_data=cast(FetchMarketData, stub_market_data_1),
+            feature_store=PandasFeatureStore(),
+            model=SklearnModelRouter(adapters=[
+                NaiveBaselineModel(),
+                HistGradientBoostingModel(),
+            ]),
+            model_registry=LocalFileModelRegistry(),
+            training_tickers=tickers,
+            supported_model_types=("hist_gbdt",),
+        )
+        request = TrainModelRequest(
+            cutoff_date="2024-06-01",
+            years=1,
+            end="2024-12-31",
+            model_types=["hist_gbdt"],
+            artifacts_dir=tmp_dir_1,
+        )
+        result_1 = train_model_1.execute(request)
+
+        # Train 2 (same data, same random_state)
+        stub_market_data_2 = _StubFetchMarketData(data)
+        train_model_2 = TrainModel(
+            fetch_market_data=cast(FetchMarketData, stub_market_data_2),
+            feature_store=PandasFeatureStore(),
+            model=SklearnModelRouter(adapters=[
+                NaiveBaselineModel(),
+                HistGradientBoostingModel(),
+            ]),
+            model_registry=LocalFileModelRegistry(),
+            training_tickers=tickers,
+            supported_model_types=("hist_gbdt",),
+        )
+        request = TrainModelRequest(
+            cutoff_date="2024-06-01",
+            years=1,
+            end="2024-12-31",
+            model_types=["hist_gbdt"],
+            artifacts_dir=tmp_dir_2,
+        )
+        result_2 = train_model_2.execute(request)
+
+        # Load predictions from both runs
+        pred_path_1 = Path(result_1.run_dirs["hist_gbdt"]) / "predictions.csv"
+        pred_path_2 = Path(result_2.run_dirs["hist_gbdt"]) / "predictions.csv"
+
+        pred_df_1 = pd.read_csv(pred_path_1)
+        pred_df_2 = pd.read_csv(pred_path_2)
+
+        # Verify predictions are identical (deterministic)
+        pd.testing.assert_frame_equal(pred_df_1, pred_df_2)
+
+
+def test_hist_gbdt_config_integration() -> None:
+    """Verify hist_gbdt is discoverable and configurable in Settings."""
+    from finsight.config.settings import get_settings
+
+    settings = get_settings()
+
+    # Verify hist_gbdt is in training models
+    training_ids = settings.model_defaults.training_model_ids()
+    assert "hist_gbdt" in training_ids
+
+    # Verify hist_gbdt is in prediction models
+    prediction_ids = settings.model_defaults.prediction_model_ids()
+    assert "hist_gbdt" in prediction_ids
+
+    # Verify label mapping
+    id_to_label = settings.model_defaults.id_to_label()
+    assert id_to_label["hist_gbdt"] == "Histogram Gradient Boosting"
+
+
+def test_hist_gbdt_router_integration() -> None:
+    """Verify hist_gbdt is registered in router via container."""
+    from finsight.bootstrap.container import build_container
+
+    build_container.cache_clear()
+    container = build_container()
+
+    router = container.train_model._model
+    supported_types = router.supported_model_types()
+
+    assert "hist_gbdt" in supported_types
+    assert ("naive_zero", "naive_mean", "ridge", "hist_gbdt") == supported_types
+
+
+def test_hist_gbdt_produces_valid_metadata() -> None:
+    """Verify hist_gbdt metadata is serializable and complete."""
+    with TemporaryDirectory() as tmp_dir:
+        tickers = ("AAPL",)
+        data = {ticker: _make_synthetic_ohlcv_series(ticker) for ticker in tickers}
+        stub_market_data = _StubFetchMarketData(data)
+
+        train_model = TrainModel(
+            fetch_market_data=cast(FetchMarketData, stub_market_data),
+            feature_store=PandasFeatureStore(),
+            model=SklearnModelRouter(adapters=[HistGradientBoostingModel()]),
+            model_registry=LocalFileModelRegistry(),
+            training_tickers=tickers,
+            supported_model_types=("hist_gbdt",),
+        )
+
+        request = TrainModelRequest(
+            cutoff_date="2024-06-01",
+            years=1,
+            end="2024-12-31",
+            model_types=["hist_gbdt"],
+            artifacts_dir=tmp_dir,
+        )
+        result = train_model.execute(request)
+
+        run_dir = result.run_dirs["hist_gbdt"]
+        manifest_path = Path(run_dir) / "manifest.json"
+
+        # Verify JSON is valid and serializable
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+        # Verify key metadata fields
+        params = manifest.get("params", {})
+        model_metadata = params.get("model_metadata", {})
+
+        assert model_metadata["model_id"] == "hist_gbdt"
+        assert model_metadata["base_estimator"] == "HistGradientBoostingRegressor"
+        assert "hyperparams" in model_metadata
+        assert model_metadata["hyperparams"]["random_state"] == 42  # Deterministic
+        assert "feature_importance_ranking" in model_metadata
+        assert isinstance(model_metadata["feature_importance_ranking"], list)
+
+
+

--- a/tests/integration/test_streamlit_ui_hist_gbdt.py
+++ b/tests/integration/test_streamlit_ui_hist_gbdt.py
@@ -1,0 +1,87 @@
+"""Verify Streamlit UI views automatically display hist_gbdt from config."""
+from __future__ import annotations
+
+from finsight.config.settings import get_settings
+
+
+def test_streamlit_views_will_show_hist_gbdt_in_training_models() -> None:
+    """Verify hist_gbdt appears in training model dropdown (train_backtest.py view)."""
+    settings = get_settings()
+    training_model_ids = list(settings.model_defaults.training_model_ids())
+
+    # Verify hist_gbdt will appear in the multiselect dropdown
+    assert "hist_gbdt" in training_model_ids
+    assert len(training_model_ids) == 4  # naive_zero, naive_mean, ridge, hist_gbdt
+
+
+def test_streamlit_views_will_show_hist_gbdt_in_prediction_models() -> None:
+    """Verify hist_gbdt appears in prediction model dropdown (predict.py view)."""
+    settings = get_settings()
+    prediction_model_ids = list(settings.model_defaults.prediction_model_ids())
+
+    # Verify hist_gbdt will appear in the selectbox dropdown
+    assert "hist_gbdt" in prediction_model_ids
+    assert len(prediction_model_ids) == 4  # naive_zero, naive_mean, ridge, hist_gbdt
+
+
+def test_streamlit_views_will_show_correct_label_for_hist_gbdt() -> None:
+    """Verify hist_gbdt label is correctly displayed in UI selectors."""
+    settings = get_settings()
+    id_to_label = settings.model_defaults.id_to_label()
+
+    # Verify the label formatter will show correct text
+    assert id_to_label["hist_gbdt"] == "Histogram Gradient Boosting"
+
+    # Verify label_to_id mapping also works (for both views)
+    label_to_id = settings.model_defaults.label_to_id()
+    assert label_to_id["Histogram Gradient Boosting"] == "hist_gbdt"
+
+
+def test_train_backtest_view_will_get_hist_gbdt_models() -> None:
+    """
+    Simulate what train_backtest.py does:
+    - Get training_model_ids from settings
+    - Build id_to_label lookup
+    - Format into UI with labels
+    """
+    settings = get_settings()
+    model_defaults = settings.model_defaults
+
+    # This is what train_backtest.py does:
+    training_model_ids = list(model_defaults.training_model_ids())
+    model_id_to_label = model_defaults.id_to_label()
+
+    # Verify hist_gbdt is discoverable
+    assert "hist_gbdt" in training_model_ids
+    assert model_id_to_label["hist_gbdt"] == "Histogram Gradient Boosting"
+
+    # Verify the multiselect would show all 4 models by default
+    assert len(training_model_ids) == 4
+
+
+def test_predict_view_will_get_hist_gbdt_models() -> None:
+    """
+    Simulate what predict.py does:
+    - Get prediction_model_ids from settings
+    - Build id_to_label lookup
+    - Format into UI with labels
+    """
+    settings = get_settings()
+    model_defaults = settings.model_defaults
+
+    # This is what predict.py does:
+    prediction_model_ids = list(model_defaults.prediction_model_ids())
+    id_to_label = model_defaults.id_to_label()
+
+    # Verify hist_gbdt is discoverable
+    assert "hist_gbdt" in prediction_model_ids
+    assert id_to_label["hist_gbdt"] == "Histogram Gradient Boosting"
+
+    # Verify the selectbox would show all 4 models
+    assert len(prediction_model_ids) == 4
+
+    # Verify default model_id logic in predict.py still works
+    default_model_id = model_defaults.default_model_id
+    assert default_model_id == "naive_zero"  # Should stay naive_zero
+    assert default_model_id in prediction_model_ids  # default should be selectable
+

--- a/tests/unit/bootstrap/test_container.py
+++ b/tests/unit/bootstrap/test_container.py
@@ -14,3 +14,30 @@ def test_build_container_exposes_compare_models_use_case(monkeypatch) -> None:
     assert isinstance(app_container.compare_models, CompareModels)
     assert app_container.compare_models is app_container.compare_models
 
+
+def test_build_container_exposes_hist_gbdt_in_router(monkeypatch) -> None:
+    """Verify hist_gbdt model adapter is registered in the router."""
+    container_module.build_container.cache_clear()
+    monkeypatch.setattr(container_module, "get_settings", lambda: Settings())
+
+    app_container = container_module.build_container()
+
+    # Get router from TrainModel use case
+    router = app_container.train_model._model
+    supported_types = router.supported_model_types()
+
+    assert "hist_gbdt" in supported_types
+    assert ("naive_zero", "naive_mean", "ridge", "hist_gbdt") == supported_types
+
+
+def test_build_container_hist_gbdt_enables_training() -> None:
+    """Verify hist_gbdt is training-enabled in config."""
+    from finsight.config.settings import get_settings
+
+    container_module.build_container.cache_clear()
+
+    # Load real settings from config file
+    settings = get_settings()
+    training_model_ids = settings.model_defaults.training_model_ids()
+    assert "hist_gbdt" in training_model_ids
+

--- a/tests/unit/infrastructure/ml/sklearn/test_tree.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_tree.py
@@ -56,8 +56,7 @@ def test_hist_gbdt_evaluates_and_returns_metrics() -> None:
     assert np.isfinite(predictions["y_pred"]).all()
 
     # Verify trained artifact
-    assert result.trained_artifact.__class__.__name__ == "Pipeline"
-    assert tuple(result.trained_artifact.named_steps.keys()) == ("scaler", "hist_gbdt")
+    assert result.trained_artifact.__class__.__name__ == "HistGradientBoostingRegressor"
 
 
 def test_hist_gbdt_reports_supported_model_types() -> None:
@@ -223,13 +222,13 @@ def test_hist_gbdt_metadata_contains_required_fields() -> None:
     # Required fields
     assert metadata["adapter"] == "HistGradientBoostingModel"
     assert metadata["model_id"] == "hist_gbdt"
-    assert metadata["estimator"] == "Pipeline"
+    assert metadata["estimator"] == "HistGradientBoostingRegressor"
     assert metadata["base_estimator"] == "HistGradientBoostingRegressor"
     assert isinstance(metadata["feature_columns"], list)
     assert metadata["n_features"] == len(metadata["feature_columns"])
     assert isinstance(metadata["hyperparams"], dict)
     assert metadata["hyperparams"]["random_state"] == RANDOM_STATE
-    assert metadata["preprocessing"]["scaler"] == "StandardScaler"
+    assert metadata["preprocessing"] == {}
     assert isinstance(metadata["feature_importance"], dict)
     assert isinstance(metadata["feature_importance_ranking"], list)
 

--- a/tests/unit/infrastructure/ml/sklearn/test_tree.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_tree.py
@@ -1,0 +1,309 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, SUPPORTED_METRIC_NAMES
+from finsight.infrastructure.ml.sklearn.tree import HistGradientBoostingModel, RANDOM_STATE
+
+
+def _synthetic_tree_frames() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Create synthetic training and test data with numeric features."""
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"]),
+            "ticker": ["AAA", "AAA", "AAA", "AAA"],
+            "ret_1d": [0.1, 0.2, 0.3, 0.4],
+            "mom_20d": [1.0, 2.0, 3.0, 4.0],
+            "volatility": [0.05, 0.06, 0.07, 0.08],
+            "target_ret_1d": [0.2, 0.4, 0.6, 0.8],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-05", "2024-01-06"]),
+            "ticker": ["AAA", "AAA"],
+            "ret_1d": [0.5, 0.6],
+            "mom_20d": [5.0, 6.0],
+            "volatility": [0.09, 0.10],
+            "target_ret_1d": [1.0, 1.2],
+        }
+    )
+    return train_df, test_df
+
+
+def test_hist_gbdt_evaluates_and_returns_metrics() -> None:
+    """Test basic evaluation produces valid metrics and predictions."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="hist_gbdt",
+        target_column="target_ret_1d",
+    )
+
+    metrics = result.metrics
+    predictions = result.predictions
+
+    # Verify metrics contain expected keys
+    assert set(SUPPORTED_METRIC_NAMES).issubset(metrics)
+    assert 0.0 <= metrics[METRIC_DIRECTION_ACCURACY] <= 1.0
+
+    # Verify prediction structure
+    assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
+    assert len(predictions) == len(test_df)
+    assert np.isfinite(predictions["y_pred"]).all()
+
+    # Verify trained artifact
+    assert result.trained_artifact.__class__.__name__ == "Pipeline"
+    assert tuple(result.trained_artifact.named_steps.keys()) == ("scaler", "hist_gbdt")
+
+
+def test_hist_gbdt_reports_supported_model_types() -> None:
+    """Test that supported_model_types returns correct tuple."""
+    model = HistGradientBoostingModel()
+    assert model.supported_model_types() == ("hist_gbdt",)
+
+
+def test_hist_gbdt_rejects_unsupported_model_type() -> None:
+    """Test evaluation rejects unknown model type."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    with pytest.raises(ValueError, match="Unsupported model type"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="random_forest",  # Unsupported
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_rejects_missing_numeric_features() -> None:
+    """Test evaluation fails when no numeric features are available."""
+    model = HistGradientBoostingModel()
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "ticker": ["AAA", "AAA"],
+            "target_ret_1d": [0.1, 0.2],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03"]),
+            "ticker": ["AAA"],
+            "target_ret_1d": [0.3],
+        }
+    )
+
+    with pytest.raises(ValueError, match="No numeric feature columns"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_rejects_non_dataframe_train() -> None:
+    """Test evaluation rejects non-DataFrame train input."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    with pytest.raises(TypeError, match="train_dataset must be a pandas DataFrame"):
+        model.evaluate(
+            train_dataset=[],  # Not a DataFrame
+            test_dataset=test_df,
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_rejects_non_dataframe_test() -> None:
+    """Test evaluation rejects non-DataFrame test input."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    with pytest.raises(TypeError, match="test_dataset must be a pandas DataFrame"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset={},  # Not a DataFrame
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_rejects_empty_train_dataset() -> None:
+    """Test evaluation rejects empty training dataset."""
+    model = HistGradientBoostingModel()
+    # Empty DataFrame has no columns, so target validation happens first
+    train_df = pd.DataFrame(columns=["date", "ticker", "ret_1d", "target_ret_1d"])
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01"]),
+            "ticker": ["AAA"],
+            "ret_1d": [0.5],
+            "target_ret_1d": [1.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="non-empty"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_rejects_empty_test_dataset() -> None:
+    """Test evaluation rejects empty test dataset."""
+    model = HistGradientBoostingModel()
+    train_df, _ = _synthetic_tree_frames()
+    # Empty DataFrame with columns to pass target column check
+    test_df = pd.DataFrame(columns=["date", "ticker", "ret_1d", "target_ret_1d"])
+
+    with pytest.raises(ValueError, match="non-empty"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_deterministic_with_random_state() -> None:
+    """Test that same random_state produces deterministic results."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    # First evaluation
+    result1 = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="hist_gbdt",
+        target_column="target_ret_1d",
+    )
+
+    # Second evaluation with same data
+    result2 = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="hist_gbdt",
+        target_column="target_ret_1d",
+    )
+
+    # Predictions should be identical
+    np.testing.assert_array_almost_equal(
+        result1.predictions["y_pred"].values,
+        result2.predictions["y_pred"].values,
+        decimal=10,
+    )
+
+    # Metrics should be identical
+    assert result1.metrics == result2.metrics
+
+
+def test_hist_gbdt_metadata_contains_required_fields() -> None:
+    """Test that model_metadata contains all required serializable fields."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="hist_gbdt",
+        target_column="target_ret_1d",
+    )
+
+    metadata = result.model_metadata
+
+    # Required fields
+    assert metadata["adapter"] == "HistGradientBoostingModel"
+    assert metadata["model_id"] == "hist_gbdt"
+    assert metadata["estimator"] == "Pipeline"
+    assert metadata["base_estimator"] == "HistGradientBoostingRegressor"
+    assert isinstance(metadata["feature_columns"], list)
+    assert metadata["n_features"] == len(metadata["feature_columns"])
+    assert isinstance(metadata["hyperparams"], dict)
+    assert metadata["hyperparams"]["random_state"] == RANDOM_STATE
+    assert metadata["preprocessing"]["scaler"] == "StandardScaler"
+    assert isinstance(metadata["feature_importance"], dict)
+    assert isinstance(metadata["feature_importance_ranking"], list)
+
+
+def test_hist_gbdt_feature_importance_ranking_ordered() -> None:
+    """Test that feature importance ranking is ordered by importance descending."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="hist_gbdt",
+        target_column="target_ret_1d",
+    )
+
+    ranking = result.model_metadata["feature_importance_ranking"]
+
+    # Verify structure
+    assert len(ranking) == result.model_metadata["n_features"]
+    for item in ranking:
+        assert "feature" in item
+        assert "importance" in item
+        assert "rank" in item
+        assert isinstance(item["importance"], float)
+        assert item["importance"] >= 0.0
+
+    # Verify ordering (descending by importance)
+    for i in range(len(ranking) - 1):
+        assert ranking[i]["importance"] >= ranking[i + 1]["importance"]
+
+
+def test_hist_gbdt_predictions_row_count_matches_test() -> None:
+    """Test that predictions DataFrame has same row count as test set."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="hist_gbdt",
+        target_column="target_ret_1d",
+    )
+
+    assert len(result.predictions) == len(test_df)
+    assert result.predictions["y_true"].notna().all()
+    assert result.predictions["y_pred"].notna().all()
+
+
+def test_hist_gbdt_missing_target_column_in_train() -> None:
+    """Test evaluation fails when target column is missing from train set."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+    train_df = train_df.drop(columns=["target_ret_1d"])
+
+    with pytest.raises(ValueError, match="must contain"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )
+
+
+def test_hist_gbdt_missing_target_column_in_test() -> None:
+    """Test evaluation fails when target column is missing from test set."""
+    model = HistGradientBoostingModel()
+    train_df, test_df = _synthetic_tree_frames()
+    test_df = test_df.drop(columns=["target_ret_1d"])
+
+    with pytest.raises(ValueError, match="must contain"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="hist_gbdt",
+            target_column="target_ret_1d",
+        )


### PR DESCRIPTION
This pull request adds support for a new machine learning model, Histogram Gradient Boosting (`hist_gbdt`), to the FinSight application. The changes include implementing the model adapter, updating the dependency injection container, expanding the CLI and documentation to reference the new model, and updating the architecture overview.

**New Model Support**

* Added a new adapter class `HistGradientBoostingModel` in `ml/sklearn/tree.py` to provide training and evaluation for the `hist_gbdt` model using scikit-learn's `HistGradientBoostingRegressor`. This includes feature selection, hyperparameter configuration, metrics computation, and feature importance extraction.
* Registered `HistGradientBoostingModel` in the dependency injection container (`container.py`) and made it available to the model router alongside existing models.

**Configuration and Documentation Updates**

* Added `hist_gbdt` to the list of supported models in `config/config.yaml`, enabling it for training and prediction.
* Updated CLI documentation to include `hist_gbdt` as a supported model for training, comparison, and forecasting, with revised examples and outputs. 
* Revised the architecture overview to document the new model adapter and its mapping to the `ModelPort` interface.