### PR TITLE
Chore/issues/54 add xgboost regressor model option to training evaluation pipeline

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,6 +42,10 @@ model_defaults:
       label: "Histogram Gradient Boosting"
       supports_training: true
       supports_prediction: true
+    - id: "xgboost"
+      label: "XGBoost"
+      supports_training: true
+      supports_prediction: true
   default_model_id: "naive_zero"
   horizon_min: 7
   horizon_max: 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
   "PyYAML",
   "numpy",
   "joblib",
-  "scikit-learn"
+  "scikit-learn",
+  "xgboost>=2.0.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,4 +65,5 @@ tzdata==2025.2
 urllib3==2.5.0
 watchdog==6.0.0
 websockets==15.0.1
+xgboost>=2.0.0
 yfinance==0.2.65

--- a/src/finsight/bootstrap/container.py
+++ b/src/finsight/bootstrap/container.py
@@ -10,7 +10,7 @@ from finsight.application.use_cases.train_model import TrainModel
 from finsight.config.settings import get_settings
 from finsight.infrastructure.features.feature_store import PandasFeatureStore
 from finsight.infrastructure.market_data.yfinance_provider import YFinanceMarketDataProvider
-from finsight.infrastructure.ml.sklearn import HistGradientBoostingModel, LinearSklearnModel, NaiveBaselineModel, SklearnModelRouter
+from finsight.infrastructure.ml.sklearn import HistGradientBoostingModel, LinearSklearnModel, NaiveBaselineModel, XGBoostModel, SklearnModelRouter
 from finsight.infrastructure.ml.registry import LocalFileModelRegistry
 
 
@@ -41,6 +41,7 @@ def build_container() -> AppContainer:
         NaiveBaselineModel(),
         LinearSklearnModel(),
         HistGradientBoostingModel(),
+        XGBoostModel(),
     ])
     model_registry = LocalFileModelRegistry()
     train_model = TrainModel(

--- a/src/finsight/infrastructure/ml/sklearn/__init__.py
+++ b/src/finsight/infrastructure/ml/sklearn/__init__.py
@@ -1,7 +1,8 @@
 from finsight.infrastructure.ml.sklearn.baseline import NaiveBaselineModel
 from finsight.infrastructure.ml.sklearn.linear import LinearSklearnModel
 from finsight.infrastructure.ml.sklearn.tree import HistGradientBoostingModel
+from finsight.infrastructure.ml.sklearn.xgboost import XGBoostModel
 from finsight.infrastructure.ml.sklearn.router import SklearnModelRouter
 
-__all__ = ["NaiveBaselineModel", "LinearSklearnModel", "HistGradientBoostingModel", "SklearnModelRouter"]
+__all__ = ["NaiveBaselineModel", "LinearSklearnModel", "HistGradientBoostingModel", "XGBoostModel", "SklearnModelRouter"]
 

--- a/src/finsight/infrastructure/ml/sklearn/tree.py
+++ b/src/finsight/infrastructure/ml/sklearn/tree.py
@@ -66,11 +66,10 @@ class HistGradientBoostingModel(ModelPort):
         )
         model.fit(x_train, y_train)
         y_pred = model.predict(x_test)
-        hist_gbdt_model = model
 
         # Compute feature importances (if available)
         try:
-            importances = getattr(hist_gbdt_model, "feature_importances_", None)
+            importances = getattr(model, "feature_importances_", None)
             if importances is not None:
                 feature_importance = self._feature_importance_ranking(feature_columns, importances)
             else:
@@ -99,7 +98,7 @@ class HistGradientBoostingModel(ModelPort):
                 "adapter": "HistGradientBoostingModel",
                 "model_id": model_type,
                 "estimator": model.__class__.__name__,
-                "base_estimator": hist_gbdt_model.__class__.__name__,
+                "base_estimator": model.__class__.__name__,
                 "feature_columns": feature_columns,
                 "n_features": len(feature_columns),
                 "hyperparams": {

--- a/src/finsight/infrastructure/ml/sklearn/xgboost.py
+++ b/src/finsight/infrastructure/ml/sklearn/xgboost.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pandas as pd
+from sklearn.inspection import permutation_importance
+from xgboost import XGBRegressor
+
+from finsight.domain.entities import ModelEvaluationResult
+from finsight.domain.metrics import forecast_metrics
+from finsight.domain.ports import ModelPort
+
+SUPPORTED_MODEL_TYPES = ("xgboost",)
+RANDOM_STATE = 42
+
+
+class XGBoostModel(ModelPort):
+    """XGBoost gradient boosting regressor adapter."""
+
+    def evaluate(
+        self,
+        *,
+        train_dataset: object,
+        test_dataset: object,
+        model_type: str,
+        target_column: str,
+        id_columns: Sequence[str] = ("date", "ticker"),
+    ) -> ModelEvaluationResult:
+        train_df = self._require_dataframe(train_dataset, arg_name="train_dataset")
+        test_df = self._require_dataframe(test_dataset, arg_name="test_dataset")
+
+        if model_type not in SUPPORTED_MODEL_TYPES:
+            raise ValueError(
+                f"Unsupported model type '{model_type}'. Supported model types: {SUPPORTED_MODEL_TYPES}."
+            )
+
+        if target_column not in train_df.columns or target_column not in test_df.columns:
+            raise ValueError(f"Both train_df and test_df must contain '{target_column}'.")
+
+        if train_df.empty or test_df.empty:
+            raise ValueError("train_df and test_df must be non-empty for evaluation.")
+
+        feature_columns = self._feature_columns(train_df, test_df, target_column=target_column, id_columns=id_columns)
+        if not feature_columns:
+            raise ValueError("No numeric feature columns available for XGBoost model evaluation.")
+
+        x_train = train_df.loc[:, feature_columns].to_numpy(dtype=float)
+        x_test = test_df.loc[:, feature_columns].to_numpy(dtype=float)
+        y_train = train_df[target_column].to_numpy(dtype=float)
+        y_test = test_df[target_column].to_numpy(dtype=float)
+
+        # Hyperparameters for XGBoost
+        n_estimators = 300
+        learning_rate = 0.03
+        max_depth = 3
+        subsample = 0.8
+        colsample_bytree = 0.8
+        reg_lambda = 1.0
+
+        model = XGBRegressor(
+            n_estimators=n_estimators,
+            learning_rate=learning_rate,
+            max_depth=max_depth,
+            subsample=subsample,
+            colsample_bytree=colsample_bytree,
+            reg_lambda=reg_lambda,
+            random_state=RANDOM_STATE,
+            verbosity=0,
+        )
+        model.fit(x_train, y_train)
+        y_pred = model.predict(x_test)
+
+        # Compute feature importances (native XGBoost importance preferred)
+        try:
+            importances = getattr(model, "feature_importances_", None)
+            if importances is not None:
+                feature_importance = self._feature_importance_ranking(feature_columns, importances)
+            else:
+                raise AttributeError
+        except AttributeError:
+            # Fallback: use permutation importance if direct importance is unavailable
+            perm_importance = permutation_importance(
+                model, x_test, y_test, n_repeats=10, random_state=RANDOM_STATE, n_jobs=-1
+            )
+            feature_importance = self._feature_importance_ranking(
+                feature_columns, perm_importance.importances_mean
+            )
+
+        metrics = forecast_metrics(y_true=y_test.tolist(), y_pred=y_pred.tolist())
+
+        pred_cols = [col for col in id_columns if col in test_df.columns]
+        predictions = test_df[pred_cols].copy() if pred_cols else pd.DataFrame(index=test_df.index)
+        predictions["y_true"] = y_test
+        predictions["y_pred"] = y_pred
+
+        return ModelEvaluationResult(
+            metrics=metrics,
+            predictions=predictions.reset_index(drop=True),
+            trained_artifact=model,
+            model_metadata={
+                "adapter": "XGBoostModel",
+                "model_id": model_type,
+                "estimator": model.__class__.__name__,
+                "base_estimator": model.__class__.__name__,
+                "feature_columns": feature_columns,
+                "n_features": len(feature_columns),
+                "hyperparams": {
+                    "n_estimators": n_estimators,
+                    "learning_rate": learning_rate,
+                    "max_depth": max_depth,
+                    "subsample": subsample,
+                    "colsample_bytree": colsample_bytree,
+                    "reg_lambda": reg_lambda,
+                    "random_state": RANDOM_STATE,
+                },
+                "preprocessing": {},
+                "feature_importance": {item["feature"]: item["importance"] for item in feature_importance},
+                "feature_importance_ranking": feature_importance,
+            },
+        )
+
+    def supported_model_types(self) -> tuple[str, ...]:
+        return SUPPORTED_MODEL_TYPES
+
+    @staticmethod
+    def _feature_columns(
+        train_df: pd.DataFrame,
+        test_df: pd.DataFrame,
+        *,
+        target_column: str,
+        id_columns: Sequence[str],
+    ) -> list[str]:
+        excluded = {target_column, *id_columns}
+        common = [col for col in train_df.columns if col in test_df.columns and col not in excluded]
+        numeric = [
+            col
+            for col in common
+            if pd.api.types.is_numeric_dtype(train_df[col])
+            and pd.api.types.is_numeric_dtype(test_df[col])
+        ]
+        return numeric
+
+    @staticmethod
+    def _require_dataframe(dataset: object, *, arg_name: str) -> pd.DataFrame:
+        if not isinstance(dataset, pd.DataFrame):
+            raise TypeError(f"{arg_name} must be a pandas DataFrame.")
+        return dataset
+
+    @staticmethod
+    def _feature_importance_ranking(
+        feature_columns: list[str], importances: object
+    ) -> list[dict[str, float | str]]:
+        importance_series = pd.Series(importances, index=feature_columns, dtype=float)
+        ranking = importance_series.sort_values(ascending=False)
+        return [
+            {
+                "feature": str(feature),
+                "importance": float(importance_series.loc[feature]),
+                "rank": int(idx + 1),
+            }
+            for idx, (feature, _) in enumerate(ranking.items())
+        ]
+

--- a/src/finsight/infrastructure/ml/sklearn/xgboost.py
+++ b/src/finsight/infrastructure/ml/sklearn/xgboost.py
@@ -149,7 +149,7 @@ class XGBoostModel(ModelPort):
     @staticmethod
     def _feature_importance_ranking(
         feature_columns: list[str], importances: object
-    ) -> list[dict[str, float | str]]:
+    ) -> list[dict[str, float | str | int]]:
         importance_series = pd.Series(importances, index=feature_columns, dtype=float)
         ranking = importance_series.sort_values(ascending=False)
         return [

--- a/src/finsight/infrastructure/ml/sklearn/xgboost.py
+++ b/src/finsight/infrastructure/ml/sklearn/xgboost.py
@@ -64,6 +64,7 @@ class XGBoostModel(ModelPort):
             subsample=subsample,
             colsample_bytree=colsample_bytree,
             reg_lambda=reg_lambda,
+            n_jobs=1,
             random_state=RANDOM_STATE,
             verbosity=0,
         )
@@ -111,6 +112,7 @@ class XGBoostModel(ModelPort):
                     "subsample": subsample,
                     "colsample_bytree": colsample_bytree,
                     "reg_lambda": reg_lambda,
+                    "n_jobs": 1,
                     "random_state": RANDOM_STATE,
                 },
                 "preprocessing": {},

--- a/tests/integration/test_hist_gbdt_e2e.py
+++ b/tests/integration/test_hist_gbdt_e2e.py
@@ -261,7 +261,7 @@ def test_hist_gbdt_router_integration() -> None:
     supported_types = router.supported_model_types()
 
     assert "hist_gbdt" in supported_types
-    assert ("naive_zero", "naive_mean", "ridge", "hist_gbdt") == supported_types
+    assert ("naive_zero", "naive_mean", "ridge", "hist_gbdt", "xgboost") == supported_types
 
 
 def test_hist_gbdt_produces_valid_metadata() -> None:

--- a/tests/integration/test_hist_gbdt_e2e.py
+++ b/tests/integration/test_hist_gbdt_e2e.py
@@ -2,14 +2,12 @@
 from __future__ import annotations
 
 import json
-from datetime import date
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from typing import cast
 
 import pandas as pd
-import pytest
 
 from finsight.application.dto import FetchMarketDataRequest, ForecastRequest, TrainModelRequest
 from finsight.application.use_cases.fetch_market_data import FetchMarketData

--- a/tests/integration/test_streamlit_ui_hist_gbdt.py
+++ b/tests/integration/test_streamlit_ui_hist_gbdt.py
@@ -21,7 +21,7 @@ def test_streamlit_views_will_show_hist_gbdt_in_prediction_models() -> None:
 
     # Verify hist_gbdt will appear in the selectbox dropdown
     assert "hist_gbdt" in prediction_model_ids
-    assert len(prediction_model_ids) == 5 # naive_zero, naive_mean, ridge, hist_gbdt, xgboost
+    assert len(prediction_model_ids) == 5  # naive_zero, naive_mean, ridge, hist_gbdt, xgboost
 
 
 def test_streamlit_views_will_show_correct_label_for_hist_gbdt() -> None:

--- a/tests/integration/test_streamlit_ui_hist_gbdt.py
+++ b/tests/integration/test_streamlit_ui_hist_gbdt.py
@@ -21,7 +21,7 @@ def test_streamlit_views_will_show_hist_gbdt_in_prediction_models() -> None:
 
     # Verify hist_gbdt will appear in the selectbox dropdown
     assert "hist_gbdt" in prediction_model_ids
-    assert len(prediction_model_ids) == 4  # naive_zero, naive_mean, ridge, hist_gbdt
+    assert len(prediction_model_ids) == 5 # naive_zero, naive_mean, ridge, hist_gbdt, xgboost
 
 
 def test_streamlit_views_will_show_correct_label_for_hist_gbdt() -> None:
@@ -77,8 +77,8 @@ def test_predict_view_will_get_hist_gbdt_models() -> None:
     assert "hist_gbdt" in prediction_model_ids
     assert id_to_label["hist_gbdt"] == "Histogram Gradient Boosting"
 
-    # Verify the selectbox would show all 4 models
-    assert len(prediction_model_ids) == 4
+    # Verify the selectbox would show all 5 models
+    assert len(prediction_model_ids) == 5
 
     # Verify default model_id logic in predict.py still works
     default_model_id = model_defaults.default_model_id

--- a/tests/integration/test_streamlit_ui_hist_gbdt.py
+++ b/tests/integration/test_streamlit_ui_hist_gbdt.py
@@ -11,7 +11,7 @@ def test_streamlit_views_will_show_hist_gbdt_in_training_models() -> None:
 
     # Verify hist_gbdt will appear in the multiselect dropdown
     assert "hist_gbdt" in training_model_ids
-    assert len(training_model_ids) == 4  # naive_zero, naive_mean, ridge, hist_gbdt
+    assert len(training_model_ids) == 5  # naive_zero, naive_mean, ridge, hist_gbdt, xgboost
 
 
 def test_streamlit_views_will_show_hist_gbdt_in_prediction_models() -> None:
@@ -55,8 +55,8 @@ def test_train_backtest_view_will_get_hist_gbdt_models() -> None:
     assert "hist_gbdt" in training_model_ids
     assert model_id_to_label["hist_gbdt"] == "Histogram Gradient Boosting"
 
-    # Verify the multiselect would show all 4 models by default
-    assert len(training_model_ids) == 4
+    # Verify the multiselect would show all 5 models by default
+    assert len(training_model_ids) == 5
 
 
 def test_predict_view_will_get_hist_gbdt_models() -> None:

--- a/tests/unit/bootstrap/test_container.py
+++ b/tests/unit/bootstrap/test_container.py
@@ -27,7 +27,7 @@ def test_build_container_exposes_hist_gbdt_in_router(monkeypatch) -> None:
     supported_types = router.supported_model_types()
 
     assert "hist_gbdt" in supported_types
-    assert ("naive_zero", "naive_mean", "ridge", "hist_gbdt") == supported_types
+    assert ("naive_zero", "naive_mean", "ridge", "hist_gbdt", "xgboost") == supported_types
 
 
 def test_build_container_hist_gbdt_enables_training() -> None:

--- a/tests/unit/infrastructure/ml/sklearn/test_xgboost.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_xgboost.py
@@ -208,6 +208,7 @@ def test_xgboost_metadata_includes_hyperparams() -> None:
     assert "colsample_bytree" in hyperparams
     assert "reg_lambda" in hyperparams
     assert "random_state" in hyperparams
+    assert "n_jobs" in hyperparams
 
     # Check values match expected defaults
     assert hyperparams["n_estimators"] == 300
@@ -217,6 +218,7 @@ def test_xgboost_metadata_includes_hyperparams() -> None:
     assert hyperparams["colsample_bytree"] == 0.8
     assert hyperparams["reg_lambda"] == 1.0
     assert hyperparams["random_state"] == 42
+    assert hyperparams["n_jobs"] == 1
 
 
 def test_xgboost_rejects_unsupported_model_type() -> None:

--- a/tests/unit/infrastructure/ml/sklearn/test_xgboost.py
+++ b/tests/unit/infrastructure/ml/sklearn/test_xgboost.py
@@ -1,0 +1,369 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, SUPPORTED_METRIC_NAMES
+from finsight.infrastructure.ml.sklearn.xgboost import XGBoostModel
+
+
+def _synthetic_xgboost_frames() -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Create synthetic training and test data for XGBoost testing."""
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"]),
+            "ticker": ["AAA", "AAA", "AAA", "AAA", "AAA"],
+            "ret_1d": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "mom_20d": [1.0, 2.0, 3.0, 4.0, 5.0],
+            "volatility": [0.5, 0.6, 0.7, 0.8, 0.9],
+            "target_ret_1d": [0.2, 0.4, 0.6, 0.8, 1.0],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-06", "2024-01-07", "2024-01-08"]),
+            "ticker": ["AAA", "AAA", "AAA"],
+            "ret_1d": [0.6, 0.7, 0.8],
+            "mom_20d": [6.0, 7.0, 8.0],
+            "volatility": [1.0, 1.1, 1.2],
+            "target_ret_1d": [1.2, 1.4, 1.6],
+        }
+    )
+    return train_df, test_df
+
+
+def test_xgboost_smoke_predicts_and_reports_metrics() -> None:
+    """Test that XGBoost model fits, predicts, and returns valid metrics."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    metrics = result.metrics
+    predictions = result.predictions
+
+    # Verify all required metrics are present
+    assert set(SUPPORTED_METRIC_NAMES).issubset(metrics)
+    assert 0.0 <= metrics[METRIC_DIRECTION_ACCURACY] <= 1.0
+
+    # Verify predictions structure
+    assert list(predictions.columns) == ["date", "ticker", "y_true", "y_pred"]
+    assert len(predictions) == len(test_df)
+    assert np.isfinite(predictions["y_pred"]).all()
+
+    # Verify trained artifact
+    assert result.trained_artifact.__class__.__name__ == "XGBRegressor"
+
+    # Verify model metadata
+    assert result.model_metadata["model_id"] == "xgboost"
+    assert result.model_metadata["base_estimator"] == "XGBRegressor"
+    assert "hyperparams" in result.model_metadata
+    assert "feature_columns" in result.model_metadata
+
+
+def test_xgboost_metrics_has_required_keys() -> None:
+    """Test that all required metrics are computed."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    metrics = result.metrics
+    assert "mae" in metrics
+    assert "rmse" in metrics
+    assert "direction_accuracy" in metrics
+    assert all(isinstance(v, float) for v in metrics.values())
+
+
+def test_xgboost_predictions_shape_and_columns() -> None:
+    """Test that predictions have correct shape and columns."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    predictions = result.predictions
+
+    # Check shape
+    assert predictions.shape[0] == len(test_df)
+    assert predictions.shape[1] == 4  # date, ticker, y_true, y_pred
+
+    # Check columns exist
+    assert "date" in predictions.columns
+    assert "ticker" in predictions.columns
+    assert "y_true" in predictions.columns
+    assert "y_pred" in predictions.columns
+
+    # Check y_true matches test targets
+    np.testing.assert_array_almost_equal(
+        predictions["y_true"].values,
+        test_df["target_ret_1d"].values,
+    )
+
+
+def test_xgboost_artifact_is_fitted_estimator() -> None:
+    """Test that trained artifact is a fitted XGBRegressor."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    artifact = result.trained_artifact
+
+    # Verify it's an XGBRegressor
+    assert artifact.__class__.__name__ == "XGBRegressor"
+
+    # Verify it has the predict method
+    assert hasattr(artifact, "predict")
+    assert callable(artifact.predict)
+
+    # Verify it has feature_importances_
+    assert hasattr(artifact, "feature_importances_")
+    assert artifact.feature_importances_ is not None
+
+
+def test_xgboost_feature_importance_present() -> None:
+    """Test that feature importance is computed and ranked."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    metadata = result.model_metadata
+
+    # Check importance dicts exist
+    assert "feature_importance" in metadata
+    assert "feature_importance_ranking" in metadata
+
+    # Check feature_importance is a dict
+    importance_dict = metadata["feature_importance"]
+    assert isinstance(importance_dict, dict)
+    assert len(importance_dict) > 0
+
+    # Check all features are present
+    expected_features = {"ret_1d", "mom_20d", "volatility"}
+    assert set(importance_dict.keys()) == expected_features
+
+    # Check feature_importance_ranking is a list
+    ranking = metadata["feature_importance_ranking"]
+    assert isinstance(ranking, list)
+    assert len(ranking) == 3
+
+    # Check ranking structure
+    for i, item in enumerate(ranking):
+        assert "feature" in item
+        assert "importance" in item
+        assert "rank" in item
+        assert item["rank"] == i + 1
+
+    # Check ranking is sorted by importance (descending)
+    for i in range(len(ranking) - 1):
+        assert ranking[i]["importance"] >= ranking[i + 1]["importance"]
+
+
+def test_xgboost_metadata_includes_hyperparams() -> None:
+    """Test that model metadata includes hyperparameters."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    metadata = result.model_metadata
+    hyperparams = metadata["hyperparams"]
+
+    # Check key hyperparameters are present
+    assert "n_estimators" in hyperparams
+    assert "learning_rate" in hyperparams
+    assert "max_depth" in hyperparams
+    assert "subsample" in hyperparams
+    assert "colsample_bytree" in hyperparams
+    assert "reg_lambda" in hyperparams
+    assert "random_state" in hyperparams
+
+    # Check values match expected defaults
+    assert hyperparams["n_estimators"] == 300
+    assert hyperparams["learning_rate"] == 0.03
+    assert hyperparams["max_depth"] == 3
+    assert hyperparams["subsample"] == 0.8
+    assert hyperparams["colsample_bytree"] == 0.8
+    assert hyperparams["reg_lambda"] == 1.0
+    assert hyperparams["random_state"] == 42
+
+
+def test_xgboost_rejects_unsupported_model_type() -> None:
+    """Test that unsupported model types raise ValueError."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    with pytest.raises(ValueError, match="Unsupported model type"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="some_other_model",
+            target_column="target_ret_1d",
+        )
+
+
+def test_xgboost_rejects_missing_numeric_features() -> None:
+    """Test that missing numeric features raise ValueError."""
+    model = XGBoostModel()
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "ticker": ["AAA", "AAA"],
+            "target_ret_1d": [0.1, 0.2],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03"]),
+            "ticker": ["AAA"],
+            "target_ret_1d": [0.3],
+        }
+    )
+
+    with pytest.raises(ValueError, match="No numeric feature columns"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="xgboost",
+            target_column="target_ret_1d",
+        )
+
+
+def test_xgboost_rejects_missing_target_column() -> None:
+    """Test that missing target column raises ValueError."""
+    model = XGBoostModel()
+    train_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"]),
+            "ticker": ["AAA", "AAA"],
+            "ret_1d": [0.1, 0.2],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2024-01-03"]),
+            "ticker": ["AAA"],
+            "ret_1d": [0.3],
+        }
+    )
+
+    with pytest.raises(ValueError, match="must contain"):
+        model.evaluate(
+            train_dataset=train_df,
+            test_dataset=test_df,
+            model_type="xgboost",
+            target_column="target_ret_1d",
+        )
+
+
+def test_xgboost_rejects_non_dataframe_input() -> None:
+    """Test that non-DataFrame inputs raise TypeError."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    with pytest.raises(TypeError, match="must be a pandas DataFrame"):
+        model.evaluate(
+            train_dataset=[],  # Not a DataFrame
+            test_dataset=test_df,
+            model_type="xgboost",
+            target_column="target_ret_1d",
+        )
+
+
+def test_xgboost_handles_custom_id_columns() -> None:
+    """Test that custom id_columns are respected."""
+    model = XGBoostModel()
+    train_df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+            "symbol": ["AAA", "AAA", "AAA"],
+            "ret_1d": [0.1, 0.2, 0.3],
+            "mom_20d": [1.0, 2.0, 3.0],
+            "target_ret_1d": [0.2, 0.4, 0.6],
+        }
+    )
+    test_df = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-04", "2024-01-05"]),
+            "symbol": ["AAA", "AAA"],
+            "ret_1d": [0.4, 0.5],
+            "mom_20d": [4.0, 5.0],
+            "target_ret_1d": [0.8, 1.0],
+        }
+    )
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+        id_columns=("timestamp", "symbol"),
+    )
+
+    predictions = result.predictions
+    assert "timestamp" in predictions.columns
+    assert "symbol" in predictions.columns
+
+
+def test_xgboost_supported_model_types() -> None:
+    """Test that supported model types are correctly reported."""
+    model = XGBoostModel()
+    assert model.supported_model_types() == ("xgboost",)
+
+
+def test_xgboost_produces_reasonable_predictions() -> None:
+    """Test that XGBoost produces numerically reasonable predictions."""
+    model = XGBoostModel()
+    train_df, test_df = _synthetic_xgboost_frames()
+
+    result = model.evaluate(
+        train_dataset=train_df,
+        test_dataset=test_df,
+        model_type="xgboost",
+        target_column="target_ret_1d",
+    )
+
+    predictions = result.predictions
+
+    # Check no NaN or infinite values
+    assert not predictions["y_pred"].isna().any()
+    assert np.isfinite(predictions["y_pred"]).all()
+
+    # Check predictions are in a reasonable range (close to training targets)
+    y_train = train_df["target_ret_1d"]
+    y_pred = predictions["y_pred"]
+
+    assert y_pred.min() >= y_train.min() - 2 * y_train.std()
+    assert y_pred.max() <= y_train.max() + 2 * y_train.std()
+


### PR DESCRIPTION
This pull request adds support for XGBoost regression models to the machine learning infrastructure, making XGBoost available as a model option for training and evaluation. It introduces a new `XGBoostModel` adapter, integrates it into the model registry and router, updates configuration and dependencies, and provides comprehensive unit tests to ensure correct functionality and robustness.

**XGBoost Model Integration:**

* Added a new `XGBoostModel` adapter in `src/finsight/infrastructure/ml/sklearn/xgboost.py`, implementing the required interface for model evaluation, feature importance extraction, and metadata reporting.
* Registered `XGBoostModel` in the ML model router and container, enabling it for use in the application. 
* Declared XGBoost as a supported model type in configuration (`config/config.yaml`) and ensured it is included in the router's supported types.

**Dependency and Configuration Updates:**

* Added `xgboost>=2.0.0` to the project dependencies in `pyproject.toml`.

**Testing and Validation:**

* Introduced a new unit test suite for `XGBoostModel` covering fitting, prediction, metrics, feature importance, metadata, error handling, and edge cases in `tests/unit/infrastructure/ml/sklearn/test_xgboost.py`.
* Updated existing tests to include XGBoost in the list of supported model types.

**Minor Fixes:**

* Cleaned up unused imports in integration tests.
* Minor refactor in `HistGradientBoostingModel` to simplify feature importance and metadata reporting.