### PR TITLE
Add walk-forward backtest use case

### DIFF
--- a/src/finsight/adapters/web_streamlit/presenters.py
+++ b/src/finsight/adapters/web_streamlit/presenters.py
@@ -287,6 +287,7 @@ class TrainPresenter:
         history_dates = sorted(history_map.keys())
 
         for idx, row in working.reset_index(drop=True).iterrows():
+            row_idx = int(idx)
             input_dt = row["date"].date()
             y_pred = _as_float(row.get("y_pred"))
             if y_pred is None:
@@ -309,8 +310,8 @@ class TrainPresenter:
             # Determine next_date: prefer next prediction row date, else first available history date after input
             next_date_dt = None
             # prefer next row in predictions (same ticker) if it exists
-            if idx + 1 < len(working):
-                next_row_dt = working.loc[idx + 1, "date"]
+            if row_idx + 1 < len(working):
+                next_row_dt = working.loc[row_idx + 1, "date"]
                 if pd.notna(next_row_dt):
                     next_date_dt = next_row_dt.date()
 
@@ -352,5 +353,60 @@ class TrainPresenter:
         return pd.DataFrame(rows)
 
 
-__all__ = ["ForecastPresenter", "ComparisonPresenter", "TrainPresenter"]
+class BacktestPresenter:
+    """Converts BacktestReport into display-ready frames."""
+
+    @staticmethod
+    def format_model_metrics_frame(
+        report: application_dto.BacktestReport,
+        *,
+        label_lookup: Mapping[str, str],
+    ) -> pd.DataFrame:
+        if not report.results:
+            return pd.DataFrame()
+
+        rows: list[dict[str, object]] = []
+        for result in report.results:
+            row: dict[str, object] = {
+                "model": label_lookup.get(result.model_id, result.model_id),
+                "model_id": result.model_id,
+            }
+            row.update(result.metrics)
+            rows.append(row)
+
+        frame = pd.DataFrame(rows)
+        if frame.empty:
+            return frame
+        cols = [c for c in ["model", "model_id"] if c in frame.columns] + [c for c in frame.columns if c not in ("model", "model_id")]
+        return frame[cols]
+
+    @staticmethod
+    def format_fold_frame(result: application_dto.BacktestResult) -> pd.DataFrame:
+        if not result.folds:
+            return pd.DataFrame()
+
+        frame = pd.DataFrame(result.folds)
+        if frame.empty:
+            return frame
+
+        if "metrics" in frame.columns:
+            metrics_frame = frame["metrics"].apply(lambda val: val if isinstance(val, dict) else {}).apply(pd.Series)
+            metrics_frame = metrics_frame.add_prefix("metric_")
+            frame = pd.concat([frame.drop(columns=["metrics"]), metrics_frame], axis=1)
+
+        preferred = [
+            "fold_index",
+            "train_start",
+            "train_end",
+            "test_start",
+            "test_end",
+            "n_train",
+            "n_test",
+        ]
+        ordered = [col for col in preferred if col in frame.columns]
+        remaining = [col for col in frame.columns if col not in ordered]
+        return frame[ordered + sorted(remaining)]
+
+
+__all__ = ["ForecastPresenter", "ComparisonPresenter", "TrainPresenter", "BacktestPresenter"]
 

--- a/src/finsight/adapters/web_streamlit/presenters.py
+++ b/src/finsight/adapters/web_streamlit/presenters.py
@@ -287,7 +287,7 @@ class TrainPresenter:
         history_dates = sorted(history_map.keys())
 
         for idx, row in working.reset_index(drop=True).iterrows():
-            row_idx = int(idx)
+            row_idx = idx
             input_dt = row["date"].date()
             y_pred = _as_float(row.get("y_pred"))
             if y_pred is None:

--- a/src/finsight/adapters/web_streamlit/views/__init__.py
+++ b/src/finsight/adapters/web_streamlit/views/__init__.py
@@ -1,14 +1,18 @@
 from .home import render as render_landing
 from .predict import render as render_predictor
 from .compare import render as render_comparison
+from .backtest import render as render_backtest
 from .layout import render_sidebar as render_layout
-from .train_backtest import render as render_train_backtest
+from .train_model import render as render_train_model
+# Backward compatibility alias
+from .train_model import render as render_train_backtest
 
 # Page handlers mapping
 PAGE_HANDLERS = {
     "Home": render_landing,
     "Predict": render_predictor,
+    "Backtest": render_backtest,
+    "Train Model": render_train_model,
     "Compare Models": render_comparison,
-    "Train & Backtest": render_train_backtest,
 }
 

--- a/src/finsight/adapters/web_streamlit/views/backtest.py
+++ b/src/finsight/adapters/web_streamlit/views/backtest.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from finsight.adapters.web_streamlit.presenters import BacktestPresenter
+from finsight.application.dto import BacktestRequest
+from finsight.application.use_cases.backtest import Backtest
+from finsight.bootstrap.container import build_container
+from finsight.config.settings import get_settings
+
+
+_SETTINGS = get_settings()
+
+
+@st.cache_resource(ttl=_SETTINGS.cache.resource_ttl_seconds)
+def _backtest_uc() -> Backtest:
+    return build_container().backtest
+
+
+def render() -> None:
+    st.title("Walk-Forward Backtesting")
+    st.markdown(
+        "Run walk-forward evaluation across one or more models using the configured training ticker basket. "
+        "This page is dedicated to robust model comparison and does not persist model artifacts."
+    )
+
+    model_defaults = _SETTINGS.model_defaults
+    model_ids = list(model_defaults.training_model_ids())
+    id_to_label = model_defaults.id_to_label()
+
+    if not model_ids:
+        st.warning("No training-enabled models are configured.")
+        return
+
+    with st.form("walk_forward_backtest_form"):
+        selected_model_ids = st.multiselect(
+            "Models to backtest",
+            model_ids,
+            default=model_ids,
+            format_func=lambda model_id: id_to_label.get(model_id, model_id),
+        )
+        years = int(st.slider("History window (years)", min_value=1, max_value=5, value=2))
+        min_train_days = int(st.number_input("Minimum train window (days)", min_value=30, value=252, step=1))
+        test_window_days = int(st.number_input("Test window per fold (days)", min_value=1, value=21, step=1))
+        step_days = int(st.number_input("Step size between folds (days)", min_value=1, value=21, step=1))
+        max_folds = int(st.number_input("Maximum folds", min_value=1, value=6, step=1))
+        submit = st.form_submit_button("Run walk-forward backtest")
+
+    if not submit:
+        st.info("Choose models and walk-forward settings, then run backtest.")
+        return
+
+    if not selected_model_ids:
+        st.warning("Select at least one model to backtest.")
+        return
+
+    try:
+        report = _backtest_uc().execute(
+            BacktestRequest(
+                model_ids=list(selected_model_ids),
+                years=years,
+                min_train_days=min_train_days,
+                test_window_days=test_window_days,
+                step_days=step_days,
+                max_folds=max_folds,
+            )
+        )
+    except (ValueError, TypeError) as error:
+        st.error(f"Unable to run backtest: {error}")
+        return
+    except Exception as error:  # pragma: no cover - defensive fallback for UI resilience
+        st.error(f"Backtest failed unexpectedly: {error}")
+        return
+
+    summary_frame = BacktestPresenter.format_model_metrics_frame(report, label_lookup=id_to_label)
+    if summary_frame.empty:
+        st.warning("No backtest rows were returned.")
+        return
+
+    st.subheader("Backtest summary by model")
+    st.dataframe(summary_frame, use_container_width=True, hide_index=True)
+
+    fold_count = report.split_spec.get("fold_count")
+    if fold_count is not None:
+        st.caption(f"Walk-forward folds evaluated: {fold_count}")
+
+    st.subheader("Fold-level details")
+    for result in report.results:
+        model_label = id_to_label.get(result.model_id, result.model_id)
+        st.markdown(f"**{model_label}**")
+        fold_frame = BacktestPresenter.format_fold_frame(result)
+        if fold_frame.empty:
+            st.info(f"No fold rows available for {model_label}.")
+            continue
+        st.dataframe(fold_frame, use_container_width=True, hide_index=True)
+

--- a/src/finsight/adapters/web_streamlit/views/layout.py
+++ b/src/finsight/adapters/web_streamlit/views/layout.py
@@ -6,8 +6,8 @@ def render_sidebar():
     with st.sidebar:
         selected = option_menu(
             None,
-            ["Home", "Predict", "Train & Backtest", "Compare Models"],
-            icons=["house", "graph-up", "activity", "bar-chart"],
+            ["Home", "Predict", "Backtest", "Train Model", "Compare Models"],
+            icons=["house", "graph-up", "calendar3", "activity", "bar-chart"],
             menu_icon="cast",
             default_index=0,
         )

--- a/src/finsight/adapters/web_streamlit/views/train_model.py
+++ b/src/finsight/adapters/web_streamlit/views/train_model.py
@@ -57,7 +57,7 @@ def render() -> None:
         format_func=lambda symbol: ticker_label_lookup.get(symbol, symbol),
     )
 
-    with st.form("train_backtest_form"):
+    with st.form("train_model_form"):
         st.info(f"Training configuration (fixed):\n- Cutoff date: {default_cutoff}\n- Lookback window: {_DEFAULT_YEARS} years\n- Training tickers: {', '.join(all_tickers)}")
 
         # Model selection
@@ -68,7 +68,7 @@ def render() -> None:
             format_func=lambda model_id: model_id_to_label.get(model_id, model_id),
         )
 
-        submit = st.form_submit_button("Run training & backtest")
+        submit = st.form_submit_button("Run training")
 
     # If form submitted, run training and cache results in session_state
     if submit:
@@ -90,7 +90,7 @@ def render() -> None:
         )
 
         try:
-            with st.spinner("Running training and backtests (this may take a while)..."):
+            with st.spinner("Running training (this may take a while)..."):
                 result = container.train_model.execute(request)
         except Exception as exc:
             st.error(f"Training failed: {exc}")
@@ -106,7 +106,7 @@ def render() -> None:
 
     # If no cached results yet, show info and return
     if "train_result" not in st.session_state:
-        st.info("Configure training options and submit to run backtest.")
+        st.info("Configure training options and submit to run training.")
         return
 
     # Use cached results; ticker selection is always live from the widget above
@@ -149,7 +149,7 @@ def render() -> None:
         st.stop()
 
     # Build combined backtest data per ticker across all models
-    st.subheader("Backtest results by ticker")
+    st.subheader("Evaluation results by ticker")
 
     # Model filter: allow user to toggle models on/off
     st.markdown("**Select models to display:**")
@@ -168,7 +168,7 @@ def render() -> None:
     for ticker in selected_tickers:
         st.markdown(f"#### {ticker}")
 
-        # Collect backtest data for all selected models for this ticker
+        # Collect evaluation data for all selected models for this ticker
         combined_backtest_data: dict[str, pd.DataFrame] = {}
         market_history_df = pd.DataFrame()
 
@@ -226,11 +226,11 @@ def render() -> None:
                 if not backtest_frame.empty:
                     combined_backtest_data[model_id] = backtest_frame
             except Exception as exc:
-                st.warning(f"Could not assemble backtest for {ticker} with {label_lookup.get(model_id, model_id)}: {exc}")
+                st.warning(f"Could not assemble results for {ticker} with {label_lookup.get(model_id, model_id)}: {exc}")
                 continue
 
         if not combined_backtest_data:
-            st.info(f"No backtest data for {ticker}.")
+            st.info(f"No evaluation data for {ticker}.")
             continue
 
         # Build combined chart data: align all models on next_date
@@ -298,5 +298,4 @@ def render() -> None:
             st.dataframe(comparison_df, use_container_width=True, hide_index=True)
 
         st.markdown("---")
-
 

--- a/src/finsight/adapters/web_streamlit/views/train_model.py
+++ b/src/finsight/adapters/web_streamlit/views/train_model.py
@@ -211,8 +211,9 @@ def render() -> None:
             # Fetch market history once per ticker (reuse for all models)
             if market_history_df.empty and start_date and end_date:
                 try:
+                    interval = manifest.get("params", {}).get("interval", "1d") if manifest else "1d"
                     market_data = container.fetch_market_data.execute(
-                        FetchMarketDataRequest(ticker=ticker, start_date=start_date, end_date=end_date, interval=manifest.get("params", {}).get("interval", "1d") if manifest else "1d", include_summary=False)
+                        FetchMarketDataRequest(ticker=ticker, start_date=start_date, end_date=end_date, interval=interval, include_summary=False)
                     )
                     market_history_df = market_data.history.df.copy()
                 except Exception:

--- a/src/finsight/application/dto.py
+++ b/src/finsight/application/dto.py
@@ -26,6 +26,15 @@ def _safe_int(value: Any, default: int) -> int:
         return default
 
 
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _string_tuple(value: Any, default: tuple[str, ...] = ()) -> tuple[str, ...]:
     if value is None:
         return default
@@ -502,6 +511,91 @@ class ForecastResult:
 
 
 @dataclass(frozen=True, slots=True)
+class BacktestRequest:
+    model_ids: list[str]
+    years: int = 2
+    end: str | None = None
+    interval: str | None = None
+    min_train_days: int = 252
+    test_window_days: int = 21
+    step_days: int = 21
+    max_folds: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_ids": list(self.model_ids),
+            "years": self.years,
+            "end": self.end,
+            "interval": self.interval,
+            "min_train_days": self.min_train_days,
+            "test_window_days": self.test_window_days,
+            "step_days": self.step_days,
+            "max_folds": self.max_folds,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> BacktestRequest:
+        raw_end = payload.get("end")
+        end = None if raw_end is None else str(raw_end).strip() or None
+
+        raw_interval = payload.get("interval")
+        interval = None if raw_interval is None else str(raw_interval).strip() or None
+
+        return cls(
+            model_ids=_string_list(payload.get("model_ids"), default=[]),
+            years=_safe_int(payload.get("years", 2), default=2),
+            end=end,
+            interval=interval,
+            min_train_days=_safe_int(payload.get("min_train_days", 252), default=252),
+            test_window_days=_safe_int(payload.get("test_window_days", 21), default=21),
+            step_days=_safe_int(payload.get("step_days", 21), default=21),
+            max_folds=_optional_int(payload.get("max_folds")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestFoldSummary:
+    fold_index: int
+    train_start: str
+    train_end: str
+    test_start: str
+    test_end: str
+    n_train: int
+    n_test: int
+    metrics: dict[str, MetricValue]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fold_index": self.fold_index,
+            "train_start": self.train_start,
+            "train_end": self.train_end,
+            "test_start": self.test_start,
+            "test_end": self.test_end,
+            "n_train": self.n_train,
+            "n_test": self.n_test,
+            "metrics": dict(self.metrics),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> BacktestFoldSummary:
+        metrics_raw = payload.get("metrics", {})
+        metrics: dict[str, MetricValue] = {}
+        if isinstance(metrics_raw, Mapping):
+            metrics = {str(key): value for key, value in metrics_raw.items()}
+
+        return cls(
+            fold_index=_safe_int(payload.get("fold_index", 0), default=0),
+            train_start=_safe_str(payload.get("train_start", "")).strip(),
+            train_end=_safe_str(payload.get("train_end", "")).strip(),
+            test_start=_safe_str(payload.get("test_start", "")).strip(),
+            test_end=_safe_str(payload.get("test_end", "")).strip(),
+            n_train=_safe_int(payload.get("n_train", 0), default=0),
+            n_test=_safe_int(payload.get("n_test", 0), default=0),
+            metrics=metrics,
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class BacktestResult:
     model_id: str
     metrics: dict[str, MetricValue]
@@ -537,6 +631,39 @@ class BacktestResult:
             metrics=metrics,
             folds=folds,
         )
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestReport:
+    results: list[BacktestResult]
+    dataset_spec: DatasetSpec | None = None
+    split_spec: dict[str, SerializableScalar] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "results": [result.to_dict() for result in self.results],
+            "dataset_spec": None if self.dataset_spec is None else self.dataset_spec.to_dict(),
+            "split_spec": dict(self.split_spec),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> BacktestReport:
+        results_raw = payload.get("results", [])
+        results: list[BacktestResult] = []
+        if isinstance(results_raw, list):
+            for row in results_raw:
+                if isinstance(row, Mapping):
+                    results.append(BacktestResult.from_dict(row))
+
+        dataset_raw = payload.get("dataset_spec")
+        dataset_spec = DatasetSpec.from_dict(dataset_raw) if isinstance(dataset_raw, Mapping) else None
+
+        split_spec_raw = payload.get("split_spec", {})
+        split_spec: dict[str, SerializableScalar] = {}
+        if isinstance(split_spec_raw, Mapping):
+            split_spec = {str(key): value for key, value in split_spec_raw.items()}
+
+        return cls(results=results, dataset_spec=dataset_spec, split_spec=split_spec)
 
 
 @dataclass(frozen=True, slots=True)
@@ -596,6 +723,9 @@ class RegistrySnapshot:
 
 
 __all__ = [
+    "BacktestFoldSummary",
+    "BacktestReport",
+    "BacktestRequest",
     "CompareModelsRequest",
     "CompareModelsResult",
     "BacktestResult",

--- a/src/finsight/application/use_cases/backtest.py
+++ b/src/finsight/application/use_cases/backtest.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from math import isfinite
+from typing import Mapping
+
+import pandas as pd
+
+import finsight.application.dto as application_dto
+from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.domain.ports import FeatureStorePort, ModelPort
+from finsight.infrastructure.features import WalkForwardSplitPolicy
+
+TARGET_COLUMN = "target_ret_1d"
+
+
+def _parse_iso_date(iso_str: str) -> date:
+    try:
+        return date.fromisoformat(iso_str)
+    except ValueError as exc:
+        raise ValueError(f"Invalid ISO 8601 date for 'end': {iso_str!r}") from exc
+
+
+def _validate_model_ids(model_ids: list[str]) -> list[str]:
+    if not model_ids:
+        raise ValueError("model_ids must contain at least one model id.")
+
+    normalized = [str(model_id).strip() for model_id in model_ids]
+    if any(not model_id for model_id in normalized):
+        raise ValueError("model_ids must not contain empty values.")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("model_ids must be unique.")
+    return normalized
+
+
+def _validate_supported_model_ids(model_ids: list[str], supported_model_ids: tuple[str, ...]) -> None:
+    unsupported = [model_id for model_id in model_ids if model_id not in supported_model_ids]
+    if unsupported:
+        raise ValueError(
+            f"Unsupported model id(s): {unsupported}. Supported model ids: {supported_model_ids}."
+        )
+
+
+def _get_training_tickers(training_tickers: tuple[str, ...] | list[str]) -> list[str]:
+    tickers = [ticker for ticker in (str(raw).strip().upper() for raw in training_tickers) if ticker]
+    if not tickers:
+        raise ValueError("Configured training tickers must contain at least one symbol.")
+    if len(set(tickers)) != len(tickers):
+        raise ValueError("Configured training tickers must not contain duplicates.")
+    return tickers
+
+
+def _coerce_numeric_metrics(
+    metrics: Mapping[str, application_dto.MetricValue],
+    *,
+    model_id: str,
+    fold_index: int,
+) -> dict[str, float]:
+    coerced: dict[str, float] = {}
+    for metric_name, metric_value in metrics.items():
+        try:
+            numeric_value = float(metric_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Metric '{metric_name}' for model '{model_id}' in fold {fold_index} must be numeric."
+            ) from exc
+        if not isfinite(numeric_value):
+            raise ValueError(
+                f"Metric '{metric_name}' for model '{model_id}' in fold {fold_index} must be finite."
+            )
+        coerced[str(metric_name)] = numeric_value
+    return coerced
+
+
+def _aggregate_fold_metrics(fold_metrics: list[dict[str, float]]) -> dict[str, application_dto.MetricValue]:
+    if not fold_metrics:
+        raise ValueError("fold_metrics must contain at least one fold metric set.")
+
+    metric_names = sorted({metric_name for metrics in fold_metrics for metric_name in metrics.keys()})
+    aggregated: dict[str, application_dto.MetricValue] = {"fold_count": len(fold_metrics)}
+    for metric_name in metric_names:
+        values = [metrics[metric_name] for metrics in fold_metrics if metric_name in metrics]
+        aggregated[metric_name] = float(sum(values) / len(values))
+    return aggregated
+
+
+class Backtest:
+    def __init__(
+        self,
+        *,
+        fetch_market_data: FetchMarketData,
+        feature_store: FeatureStorePort,
+        model: ModelPort,
+        training_tickers: tuple[str, ...] | list[str],
+        supported_model_ids: tuple[str, ...] | list[str] | None = None,
+        default_interval: str = "1d",
+    ) -> None:
+        model_supported_model_ids = self._as_tuple(model.supported_model_types())
+        configured_supported_model_ids = (
+            model_supported_model_ids
+            if supported_model_ids is None
+            else self._as_tuple(supported_model_ids)
+        )
+        _validate_model_ids(list(configured_supported_model_ids))
+        _validate_supported_model_ids(list(configured_supported_model_ids), model_supported_model_ids)
+
+        self._fetch_market_data = fetch_market_data
+        self._feature_store = feature_store
+        self._model = model
+        self._training_tickers = tuple(training_tickers)
+        self._supported_model_ids = configured_supported_model_ids
+        self._default_interval = default_interval
+
+    def execute(self, request: application_dto.BacktestRequest) -> application_dto.BacktestReport:
+        if request.years <= 0:
+            raise ValueError("years must be a positive integer.")
+
+        tickers = _get_training_tickers(self._training_tickers)
+        model_ids = _validate_model_ids(request.model_ids)
+        _validate_supported_model_ids(model_ids, self._supported_model_ids)
+
+        resolved_interval = request.interval or self._default_interval
+        end_date = _parse_iso_date(request.end) if request.end else date.today()
+        start_date = end_date - timedelta(days=(request.years * 365) - 1)
+
+        series_list = []
+        for ticker in tickers:
+            result = self._fetch_market_data.execute(
+                application_dto.FetchMarketDataRequest(
+                    ticker=ticker,
+                    start_date=start_date.isoformat(),
+                    end_date=end_date.isoformat(),
+                    interval=resolved_interval,
+                    include_summary=False,
+                )
+            )
+            series_list.append(result.history)
+
+        feature_dataset = self._feature_store.build_feature_dataset(series_list)
+        if not isinstance(feature_dataset, pd.DataFrame):
+            raise TypeError("Feature store must return a pandas DataFrame for backtesting.")
+
+        split_policy = WalkForwardSplitPolicy(
+            min_train_size=request.min_train_days,
+            test_size=request.test_window_days,
+            step_size=request.step_days,
+            date_col="date",
+            max_folds=request.max_folds,
+        )
+        folds = split_policy.split_frame(feature_dataset)
+
+        results: list[application_dto.BacktestResult] = []
+        for model_id in model_ids:
+            fold_rows: list[application_dto.SerializableRow] = []
+            fold_metrics: list[dict[str, float]] = []
+
+            for fold in folds:
+                evaluation_result = self._model.evaluate(
+                    train_dataset=fold.train_df,
+                    test_dataset=fold.test_df,
+                    model_type=model_id,
+                    target_column=TARGET_COLUMN,
+                )
+                metrics = _coerce_numeric_metrics(
+                    evaluation_result.metrics,
+                    model_id=model_id,
+                    fold_index=fold.fold_index,
+                )
+                fold_metrics.append(metrics)
+
+                fold_rows.append(
+                    application_dto.BacktestFoldSummary(
+                        fold_index=fold.fold_index,
+                        train_start=fold.train_start.isoformat(),
+                        train_end=fold.train_end.isoformat(),
+                        test_start=fold.test_start.isoformat(),
+                        test_end=fold.test_end.isoformat(),
+                        n_train=len(fold.train_df),
+                        n_test=len(fold.test_df),
+                        metrics=metrics,
+                    ).to_dict()
+                )
+
+            results.append(
+                application_dto.BacktestResult(
+                    model_id=model_id,
+                    metrics=_aggregate_fold_metrics(fold_metrics),
+                    folds=fold_rows,
+                )
+            )
+
+        return application_dto.BacktestReport(
+            results=results,
+            dataset_spec=application_dto.DatasetSpec(
+                tickers=tuple(tickers),
+                start_date=start_date.isoformat(),
+                end_date=end_date.isoformat(),
+                interval=resolved_interval,
+            ),
+            split_spec={
+                "name": "walk_forward",
+                "min_train_days": request.min_train_days,
+                "test_window_days": request.test_window_days,
+                "step_days": request.step_days,
+                "max_folds": request.max_folds,
+                "fold_count": len(folds),
+            },
+        )
+
+    @staticmethod
+    def _as_tuple(values: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+        return tuple(values)
+
+
+__all__ = ["Backtest"]
+
+

--- a/src/finsight/bootstrap/container.py
+++ b/src/finsight/bootstrap/container.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 
 from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.application.use_cases.backtest import Backtest
 from finsight.application.use_cases.compare_models import CompareModels
 from finsight.application.use_cases.forecast import Forecast
 from finsight.application.use_cases.train_model import TrainModel
@@ -20,6 +21,7 @@ class AppContainer:
     """Composition root for concrete implementations used by adapters."""
 
     fetch_market_data: FetchMarketData
+    backtest: Backtest
     train_model: TrainModel
     compare_models: CompareModels
     forecast: Forecast
@@ -59,6 +61,14 @@ def build_container() -> AppContainer:
         supported_model_types=settings.model_defaults.training_model_ids(),
         default_interval=settings.stock_data.default_interval,
     )
+    backtest = Backtest(
+        fetch_market_data=fetch_market_data,
+        feature_store=feature_store,
+        model=model,
+        training_tickers=settings.ticker_catalog.symbols(),
+        supported_model_ids=settings.model_defaults.training_model_ids(),
+        default_interval=settings.stock_data.default_interval,
+    )
     compare_models = CompareModels(model_registry=model_registry, run_registry=run_registry)
     forecast = Forecast(
         fetch_market_data=fetch_market_data,
@@ -68,6 +78,7 @@ def build_container() -> AppContainer:
 
     return AppContainer(
         fetch_market_data=fetch_market_data,
+        backtest=backtest,
         train_model=train_model,
         compare_models=compare_models,
         forecast=forecast,

--- a/src/finsight/infrastructure/features/__init__.py
+++ b/src/finsight/infrastructure/features/__init__.py
@@ -1,8 +1,10 @@
 from finsight.infrastructure.features.feature_store import PandasFeatureStore
-from finsight.infrastructure.features.policies import TimeSplitPolicy
+from finsight.infrastructure.features.policies import TimeSplitPolicy, WalkForwardFold, WalkForwardSplitPolicy
 
 __all__ = [
     "PandasFeatureStore",
     "TimeSplitPolicy",
+    "WalkForwardFold",
+    "WalkForwardSplitPolicy",
 ]
 

--- a/src/finsight/infrastructure/features/policies.py
+++ b/src/finsight/infrastructure/features/policies.py
@@ -97,3 +97,113 @@ class TimeSplitPolicy:
                 ) from exc
         raise TypeError("cutoff_date must be a datetime.date, datetime.datetime, or ISO string")
 
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardFold:
+    fold_index: int
+    train_start: date
+    train_end: date
+    test_start: date
+    test_end: date
+    train_df: pd.DataFrame
+    test_df: pd.DataFrame
+
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardSplitPolicy:
+    min_train_size: int
+    test_size: int
+    step_size: int
+    date_col: str = "date"
+    max_folds: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.min_train_size <= 0:
+            raise ValueError("min_train_size must be a positive integer.")
+        if self.test_size <= 0:
+            raise ValueError("test_size must be a positive integer.")
+        if self.step_size <= 0:
+            raise ValueError("step_size must be a positive integer.")
+        if self.max_folds is not None and self.max_folds <= 0:
+            raise ValueError("max_folds must be None or a positive integer.")
+
+    def split_frame(self, df: pd.DataFrame) -> list[WalkForwardFold]:
+        if df.empty:
+            raise ValueError(
+                "Input DataFrame is empty. Cannot perform walk-forward split on an empty dataset."
+            )
+        if self.date_col not in df.columns:
+            raise ValueError(
+                f"Missing required date column '{self.date_col}'. "
+                f"Available columns: {list(df.columns)}"
+            )
+
+        parsed_dates = pd.to_datetime(df[self.date_col], errors="coerce")
+        invalid_mask = parsed_dates.isna()
+        if invalid_mask.any():
+            invalid_count = int(invalid_mask.sum())
+            raise ValueError(
+                f"Column '{self.date_col}' contains {invalid_count} invalid date value(s)."
+            )
+
+        frame = df.copy()
+        frame[self.date_col] = parsed_dates
+        unique_dates = sorted(parsed_dates.dt.normalize().unique())
+        n_dates = len(unique_dates)
+
+        min_required = self.min_train_size + self.test_size
+        if n_dates < min_required:
+            raise ValueError(
+                "Walk-forward split cannot produce any fold. "
+                f"Need at least {min_required} unique dates, found {n_dates}."
+            )
+
+        sort_cols = ["ticker", self.date_col] if {"ticker", self.date_col}.issubset(frame.columns) else [self.date_col]
+        folds: list[WalkForwardFold] = []
+        train_cutoff_idx = self.min_train_size
+
+        while train_cutoff_idx + self.test_size <= n_dates:
+            train_end_ts = pd.Timestamp(unique_dates[train_cutoff_idx - 1]).normalize()
+            test_start_ts = pd.Timestamp(unique_dates[train_cutoff_idx]).normalize()
+            test_end_ts = pd.Timestamp(unique_dates[train_cutoff_idx + self.test_size - 1]).normalize()
+
+            train_mask = frame[self.date_col].dt.normalize() <= train_end_ts
+            test_mask = (
+                (frame[self.date_col].dt.normalize() >= test_start_ts)
+                & (frame[self.date_col].dt.normalize() <= test_end_ts)
+            )
+
+            train_df = frame.loc[train_mask].copy()
+            test_df = frame.loc[test_mask].copy()
+            if train_df.empty or test_df.empty:
+                raise ValueError(
+                    "Walk-forward split produced an empty partition. "
+                    f"train_end={train_end_ts.date().isoformat()}, "
+                    f"test_start={test_start_ts.date().isoformat()}, "
+                    f"test_end={test_end_ts.date().isoformat()}."
+                )
+
+            train_df = train_df.sort_values(sort_cols, kind="mergesort").reset_index(drop=True)
+            test_df = test_df.sort_values(sort_cols, kind="mergesort").reset_index(drop=True)
+
+            folds.append(
+                WalkForwardFold(
+                    fold_index=len(folds) + 1,
+                    train_start=train_df[self.date_col].min().date(),
+                    train_end=train_end_ts.date(),
+                    test_start=test_start_ts.date(),
+                    test_end=test_end_ts.date(),
+                    train_df=train_df,
+                    test_df=test_df,
+                )
+            )
+
+            if self.max_folds is not None and len(folds) >= self.max_folds:
+                break
+            train_cutoff_idx += self.step_size
+
+        if not folds:
+            raise ValueError("Walk-forward split cannot produce any fold with the configured parameters.")
+        return folds
+
+

--- a/tests/integration/test_backtest_e2e.py
+++ b/tests/integration/test_backtest_e2e.py
@@ -1,0 +1,108 @@
+"""Integration test for walk-forward Backtest use case."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pandas as pd
+
+from finsight.application.dto import BacktestRequest, FetchMarketDataRequest
+from finsight.application.use_cases.backtest import Backtest
+from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.domain.metrics import SUPPORTED_METRIC_NAMES
+from finsight.domain.value_objects import DateRange, Interval, Ticker
+from finsight.domain.entities import OHLCVSeries
+from finsight.infrastructure.features.feature_store import PandasFeatureStore
+from finsight.infrastructure.ml.sklearn import NaiveBaselineModel, LinearSklearnModel, SklearnModelRouter
+
+
+class _StubFetchMarketData:
+    """Stub market data provider that returns synthetic OHLCV data by ticker."""
+
+    def __init__(self, data_by_ticker: dict[str, OHLCVSeries]) -> None:
+        self._data_by_ticker = data_by_ticker
+        self.calls: list[FetchMarketDataRequest] = []
+
+    def execute(self, request: FetchMarketDataRequest) -> object:
+        self.calls.append(request)
+        return SimpleNamespace(history=self._data_by_ticker[request.ticker])
+
+
+def _make_synthetic_ohlcv_series(ticker: str) -> OHLCVSeries:
+    # Keep this deterministic and long enough for all rolling windows in feature_pipeline.
+    dates = pd.date_range("2023-01-01", "2024-12-31", freq="D")
+    close = [100.0 + (idx * 0.20) for idx in range(len(dates))]
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": close,
+            "High": close,
+            "Low": close,
+            "Close": close,
+            "Volume": [1000 + idx for idx in range(len(dates))],
+        }
+    )
+
+    return OHLCVSeries(
+        ticker=Ticker(ticker),
+        date_range=DateRange(start=dates[0].date().isoformat(), end=dates[-1].date().isoformat()),
+        interval=Interval("1d"),
+        df=df,
+    )
+
+
+def test_backtest_walk_forward_end_to_end_multiple_models() -> None:
+    tickers = ("AAPL", "JPM")
+    data = {ticker: _make_synthetic_ohlcv_series(ticker) for ticker in tickers}
+    fetch_stub = _StubFetchMarketData(data)
+
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, fetch_stub)),
+        feature_store=PandasFeatureStore(),
+        model=SklearnModelRouter(adapters=[NaiveBaselineModel(), LinearSklearnModel()]),
+        training_tickers=tickers,
+        supported_model_ids=("naive_zero", "ridge"),
+        default_interval="1d",
+    )
+
+    report = use_case.execute(
+        BacktestRequest(
+            model_ids=["naive_zero", "ridge"],
+            years=2,
+            end="2024-12-31",
+            interval="1d",
+            min_train_days=120,
+            test_window_days=30,
+            step_days=30,
+            max_folds=3,
+        )
+    )
+
+    assert len(fetch_stub.calls) == len(tickers)
+    assert report.dataset_spec is not None
+    assert report.dataset_spec.tickers == tickers
+    assert report.dataset_spec.interval == "1d"
+
+    assert report.split_spec["name"] == "walk_forward"
+    assert report.split_spec["fold_count"] == 3
+
+    assert len(report.results) == 2
+    by_model = {row.model_id: row for row in report.results}
+    assert set(by_model.keys()) == {"naive_zero", "ridge"}
+
+    for model_id in ("naive_zero", "ridge"):
+        result = by_model[model_id]
+        assert result.metrics["fold_count"] == 3
+        assert set(SUPPORTED_METRIC_NAMES).issubset(result.metrics.keys())
+
+        assert len(result.folds) == 3
+        for fold in result.folds:
+            assert int(fold["fold_index"]) >= 1
+            assert int(fold["n_train"]) > 0
+            assert int(fold["n_test"]) > 0
+            assert isinstance(fold["train_start"], str)
+            assert isinstance(fold["train_end"], str)
+            assert isinstance(fold["test_start"], str)
+            assert isinstance(fold["test_end"], str)
+            assert set(SUPPORTED_METRIC_NAMES).issubset(fold["metrics"].keys())
+

--- a/tests/integration/test_streamlit_ui_hist_gbdt.py
+++ b/tests/integration/test_streamlit_ui_hist_gbdt.py
@@ -5,7 +5,7 @@ from finsight.config.settings import get_settings
 
 
 def test_streamlit_views_will_show_hist_gbdt_in_training_models() -> None:
-    """Verify hist_gbdt appears in training model dropdown (train_backtest.py view)."""
+    """Verify hist_gbdt appears in training model dropdown (train_model.py view)."""
     settings = get_settings()
     training_model_ids = list(settings.model_defaults.training_model_ids())
 
@@ -37,9 +37,9 @@ def test_streamlit_views_will_show_correct_label_for_hist_gbdt() -> None:
     assert label_to_id["Histogram Gradient Boosting"] == "hist_gbdt"
 
 
-def test_train_backtest_view_will_get_hist_gbdt_models() -> None:
+def test_train_model_view_will_get_hist_gbdt_models() -> None:
     """
-    Simulate what train_backtest.py does:
+    Simulate what train_model.py does:
     - Get training_model_ids from settings
     - Build id_to_label lookup
     - Format into UI with labels
@@ -47,7 +47,7 @@ def test_train_backtest_view_will_get_hist_gbdt_models() -> None:
     settings = get_settings()
     model_defaults = settings.model_defaults
 
-    # This is what train_backtest.py does:
+    # This is what train_model.py does:
     training_model_ids = list(model_defaults.training_model_ids())
     model_id_to_label = model_defaults.id_to_label()
 

--- a/tests/unit/adapters/web_streamlit/test_presenters.py
+++ b/tests/unit/adapters/web_streamlit/test_presenters.py
@@ -506,6 +506,14 @@ class TestTrainPresenter:
 
 
 class TestBacktestPresenter:
+    def test_format_model_metrics_frame_returns_empty_dataframe_for_empty_report(self) -> None:
+        report = BacktestReport(results=[])
+
+        frame = BacktestPresenter.format_model_metrics_frame(report, label_lookup={})
+
+        assert isinstance(frame, pd.DataFrame)
+        assert frame.empty
+
     def test_format_model_metrics_frame_applies_labels(self) -> None:
         report = BacktestReport(
             results=[
@@ -522,6 +530,32 @@ class TestBacktestPresenter:
         assert list(frame.columns) == ["model", "model_id", "fold_count", "mae", "rmse"]
         assert frame.iloc[0]["model"] == "Ridge Regression"
         assert frame.iloc[0]["model_id"] == "ridge"
+
+    def test_format_model_metrics_frame_falls_back_to_model_id_and_preserves_extra_metrics(self) -> None:
+        report = BacktestReport(
+            results=[
+                BacktestResult(
+                    model_id="naive_zero",
+                    metrics={"z_metric": 1.0, "mae": 0.1},
+                    folds=[],
+                )
+            ]
+        )
+
+        frame = BacktestPresenter.format_model_metrics_frame(report, label_lookup={})
+
+        assert list(frame.columns) == ["model", "model_id", "z_metric", "mae"]
+        assert frame.iloc[0]["model"] == "naive_zero"
+        assert frame.iloc[0]["model_id"] == "naive_zero"
+        assert frame.iloc[0]["z_metric"] == 1.0
+
+    def test_format_fold_frame_returns_empty_dataframe_for_empty_folds(self) -> None:
+        result = BacktestResult(model_id="ridge", metrics={"fold_count": 0}, folds=[])
+
+        frame = BacktestPresenter.format_fold_frame(result)
+
+        assert isinstance(frame, pd.DataFrame)
+        assert frame.empty
 
     def test_format_fold_frame_flattens_metrics(self) -> None:
         result = BacktestResult(
@@ -555,4 +589,30 @@ class TestBacktestPresenter:
         assert frame.iloc[0]["metric_mae"] == 0.12
         assert frame.iloc[0]["metric_rmse"] == 0.19
 
+    def test_format_fold_frame_treats_non_mapping_metrics_as_empty_and_sorts_remaining_columns(self) -> None:
+        result = BacktestResult(
+            model_id="ridge",
+            metrics={"fold_count": 1},
+            folds=cast(
+                list[application_dto.SerializableRow],
+                cast(
+                    object,
+                    [
+                        {
+                            "fold_index": 1,
+                            "n_test": 20,
+                            "z_extra": "last",
+                            "a_extra": "first",
+                            "metrics": None,
+                        }
+                    ],
+                ),
+            ),
+        )
+
+        frame = BacktestPresenter.format_fold_frame(result)
+
+        assert "metrics" not in frame.columns
+        assert list(frame.columns) == ["fold_index", "n_test", "a_extra", "z_extra"]
+        assert frame.iloc[0]["a_extra"] == "first"
 

--- a/tests/unit/adapters/web_streamlit/test_presenters.py
+++ b/tests/unit/adapters/web_streamlit/test_presenters.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 import pandas as pd
 import pytest
+from typing import cast
 
-from finsight.adapters.web_streamlit.presenters import ComparisonPresenter, ForecastPresenter, TrainPresenter
-from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow, TrainModelResult
+from finsight.adapters.web_streamlit.presenters import BacktestPresenter, ComparisonPresenter, ForecastPresenter, TrainPresenter
+from finsight.application.dto import BacktestReport, BacktestResult, CompareModelsResult, ForecastResult, ModelComparisonRow, TrainModelResult
+import finsight.application.dto as application_dto
 
 
 class TestForecastPresenter:
@@ -501,5 +503,56 @@ class TestTrainPresenter:
         assert frame.iloc[0]["base_close"] == 100.0
         assert frame.iloc[0]["pred_next_close"] == pytest.approx(102.0)
         assert frame.iloc[0]["actual_next_close"] == pytest.approx(101.0)
+
+
+class TestBacktestPresenter:
+    def test_format_model_metrics_frame_applies_labels(self) -> None:
+        report = BacktestReport(
+            results=[
+                BacktestResult(
+                    model_id="ridge",
+                    metrics={"fold_count": 2, "mae": 0.1, "rmse": 0.2},
+                    folds=[],
+                )
+            ]
+        )
+
+        frame = BacktestPresenter.format_model_metrics_frame(report, label_lookup={"ridge": "Ridge Regression"})
+
+        assert list(frame.columns) == ["model", "model_id", "fold_count", "mae", "rmse"]
+        assert frame.iloc[0]["model"] == "Ridge Regression"
+        assert frame.iloc[0]["model_id"] == "ridge"
+
+    def test_format_fold_frame_flattens_metrics(self) -> None:
+        result = BacktestResult(
+            model_id="ridge",
+            metrics={"fold_count": 1, "mae": 0.1},
+            folds=cast(
+                list[application_dto.SerializableRow],
+                cast(
+                    object,
+                [
+                    {
+                        "fold_index": 1,
+                        "train_start": "2024-01-01",
+                        "train_end": "2024-06-01",
+                        "test_start": "2024-06-02",
+                        "test_end": "2024-07-01",
+                        "n_train": 120,
+                        "n_test": 20,
+                        "metrics": {"mae": 0.12, "rmse": 0.19},
+                    }
+                ],
+                ),
+            ),
+        )
+
+        frame = BacktestPresenter.format_fold_frame(result)
+
+        assert len(frame) == 1
+        assert "metrics" not in frame.columns
+        assert frame.iloc[0]["fold_index"] == 1
+        assert frame.iloc[0]["metric_mae"] == 0.12
+        assert frame.iloc[0]["metric_rmse"] == 0.19
 
 

--- a/tests/unit/adapters/web_streamlit/test_views_presenter_wiring.py
+++ b/tests/unit/adapters/web_streamlit/test_views_presenter_wiring.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 
 import pandas as pd
 import pytest
 
 import finsight.adapters.web_streamlit.views.compare as compare_view
 import finsight.adapters.web_streamlit.views.predict as predict_view
-import finsight.adapters.web_streamlit.views.train_backtest as train_backtest_view
-from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow
+import finsight.adapters.web_streamlit.views.backtest as backtest_view
+import finsight.adapters.web_streamlit.views.train_model as train_model_view
+import finsight.application.dto as application_dto
+from finsight.application.dto import BacktestReport, BacktestResult, CompareModelsResult, ForecastResult, ModelComparisonRow
 
 
 class _Ctx:
@@ -327,13 +330,13 @@ def test_predict_render_executes_forecast_use_case_and_renders_result(monkeypatc
     assert not any(kind == "error" for kind, _ in events)
 
 
-def test_train_backtest_render_shows_info_when_no_cached_results(monkeypatch) -> None:
+def test_train_model_render_shows_info_when_no_cached_results(monkeypatch) -> None:
     events: list[tuple[str, str]] = []
 
     session_state = _SessionState()
-    monkeypatch.setattr(train_backtest_view.st, "session_state", session_state, raising=False)
+    monkeypatch.setattr(train_model_view.st, "session_state", session_state, raising=False)
     monkeypatch.setattr(
-        train_backtest_view,
+        train_model_view,
         "_SETTINGS",
         SimpleNamespace(
             model_defaults=SimpleNamespace(
@@ -346,28 +349,28 @@ def test_train_backtest_render_shows_info_when_no_cached_results(monkeypatch) ->
             ),
         ),
     )
-    monkeypatch.setattr(train_backtest_view, "build_container", lambda: SimpleNamespace())
-    monkeypatch.setattr(train_backtest_view, "build_ticker_select_items", lambda _entries: [("AAPL", "Apple Inc.")])
-    monkeypatch.setattr(train_backtest_view.st, "title", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "markdown", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "info", lambda msg: events.append(("info", msg)))
-    monkeypatch.setattr(train_backtest_view.st, "warning", lambda msg: events.append(("warning", msg)))
-    monkeypatch.setattr(train_backtest_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
-    monkeypatch.setattr(train_backtest_view.st, "form", lambda _name: _Ctx())
-    monkeypatch.setattr(train_backtest_view.st, "form_submit_button", lambda _label: False)
+    monkeypatch.setattr(train_model_view, "build_container", lambda: SimpleNamespace())
+    monkeypatch.setattr(train_model_view, "build_ticker_select_items", lambda _entries: [("AAPL", "Apple Inc.")])
+    monkeypatch.setattr(train_model_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "info", lambda msg: events.append(("info", msg)))
+    monkeypatch.setattr(train_model_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(train_model_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
+    monkeypatch.setattr(train_model_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(train_model_view.st, "form_submit_button", lambda _label: False)
 
-    train_backtest_view.render()
+    train_model_view.render()
 
-    assert ("info", "Configure training options and submit to run backtest.") in events
+    assert ("info", "Configure training options and submit to run training.") in events
 
 
-def test_train_backtest_render_warns_when_no_models_selected(monkeypatch) -> None:
+def test_train_model_render_warns_when_no_models_selected(monkeypatch) -> None:
     events: list[tuple[str, str]] = []
 
     session_state = _SessionState()
-    monkeypatch.setattr(train_backtest_view.st, "session_state", session_state, raising=False)
+    monkeypatch.setattr(train_model_view.st, "session_state", session_state, raising=False)
     monkeypatch.setattr(
-        train_backtest_view,
+        train_model_view,
         "_SETTINGS",
         SimpleNamespace(
             model_defaults=SimpleNamespace(
@@ -380,22 +383,22 @@ def test_train_backtest_render_warns_when_no_models_selected(monkeypatch) -> Non
             ),
         ),
     )
-    monkeypatch.setattr(train_backtest_view, "build_container", lambda: SimpleNamespace())
-    monkeypatch.setattr(train_backtest_view, "build_ticker_select_items", lambda _entries: [("AAPL", "Apple Inc.")])
-    monkeypatch.setattr(train_backtest_view.st, "title", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "markdown", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "info", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "warning", lambda msg: events.append(("warning", msg)))
-    monkeypatch.setattr(train_backtest_view.st, "multiselect", lambda label, options, **_kwargs: [] if label == "Models to train" else list(options))
-    monkeypatch.setattr(train_backtest_view.st, "form", lambda _name: _Ctx())
-    monkeypatch.setattr(train_backtest_view.st, "form_submit_button", lambda _label: True)
+    monkeypatch.setattr(train_model_view, "build_container", lambda: SimpleNamespace())
+    monkeypatch.setattr(train_model_view, "build_ticker_select_items", lambda _entries: [("AAPL", "Apple Inc.")])
+    monkeypatch.setattr(train_model_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "info", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(train_model_view.st, "multiselect", lambda label, options, **_kwargs: [] if label == "Models to train" else list(options))
+    monkeypatch.setattr(train_model_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(train_model_view.st, "form_submit_button", lambda _label: True)
 
-    train_backtest_view.render()
+    train_model_view.render()
 
     assert ("warning", "Select at least one model to train.") in events
 
 
-def test_train_backtest_render_stops_when_no_predictions_are_available(monkeypatch) -> None:
+def test_train_model_render_stops_when_no_predictions_are_available(monkeypatch) -> None:
     events: list[tuple[str, str]] = []
 
     session_state = _SessionState(
@@ -403,19 +406,110 @@ def test_train_backtest_render_stops_when_no_predictions_are_available(monkeypat
         selected_tickers=["AAPL"],
         label_lookup={"ridge": "Ridge Regression"},
     )
-    monkeypatch.setattr(train_backtest_view.st, "session_state", session_state, raising=False)
-    monkeypatch.setattr(train_backtest_view.TrainPresenter, "load_predictions_csv", staticmethod(lambda _run_dir: None))
-    monkeypatch.setattr(train_backtest_view.st, "title", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "markdown", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "info", lambda msg: events.append(("info", msg)))
-    monkeypatch.setattr(train_backtest_view.st, "warning", lambda msg: events.append(("warning", msg)))
-    monkeypatch.setattr(train_backtest_view.st, "subheader", lambda _msg: None)
-    monkeypatch.setattr(train_backtest_view.st, "dataframe", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(train_backtest_view.st, "stop", lambda: (_ for _ in ()).throw(SystemExit))
+    monkeypatch.setattr(train_model_view.st, "session_state", session_state, raising=False)
+    monkeypatch.setattr(train_model_view.TrainPresenter, "load_predictions_csv", staticmethod(lambda _run_dir: None))
+    monkeypatch.setattr(train_model_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "info", lambda msg: events.append(("info", msg)))
+    monkeypatch.setattr(train_model_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(train_model_view.st, "subheader", lambda _msg: None)
+    monkeypatch.setattr(train_model_view.st, "dataframe", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(train_model_view.st, "stop", lambda: (_ for _ in ()).throw(SystemExit))
 
     with pytest.raises(SystemExit):
-        train_backtest_view.render()
+        train_model_view.render()
 
     assert ("warning", "No predictions data available for any model.") in events
+
+
+def test_backtest_render_shows_info_when_form_not_submitted(monkeypatch) -> None:
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(backtest_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: ("ridge",),
+        id_to_label=lambda: {"ridge": "Ridge Regression"},
+    )))
+    monkeypatch.setattr(backtest_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(backtest_view.st, "markdown", lambda _msg: None)
+    monkeypatch.setattr(backtest_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(backtest_view.st, "info", lambda msg: events.append(("info", msg)))
+    monkeypatch.setattr(backtest_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(backtest_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
+    monkeypatch.setattr(backtest_view.st, "slider", lambda _label, **_kwargs: 2)
+    monkeypatch.setattr(backtest_view.st, "number_input", lambda _label, **_kwargs: int(_kwargs.get("value", 1)))
+    monkeypatch.setattr(backtest_view.st, "form_submit_button", lambda _label: False)
+
+    backtest_view.render()
+
+    assert ("info", "Choose models and walk-forward settings, then run backtest.") in events
+
+
+def test_backtest_render_happy_path_renders_summary_and_folds(monkeypatch) -> None:
+    events: list[tuple[str, object]] = []
+
+    monkeypatch.setattr(backtest_view, "_SETTINGS", SimpleNamespace(model_defaults=SimpleNamespace(
+        training_model_ids=lambda: ("ridge",),
+        id_to_label=lambda: {"ridge": "Ridge Regression"},
+    )))
+    monkeypatch.setattr(backtest_view.st, "title", lambda _msg: None)
+    monkeypatch.setattr(backtest_view.st, "markdown", lambda msg: events.append(("markdown", msg)))
+    monkeypatch.setattr(backtest_view.st, "warning", lambda msg: events.append(("warning", msg)))
+    monkeypatch.setattr(backtest_view.st, "info", lambda msg: events.append(("info", msg)))
+    monkeypatch.setattr(backtest_view.st, "error", lambda msg: events.append(("error", msg)))
+    monkeypatch.setattr(backtest_view.st, "subheader", lambda msg: events.append(("subheader", msg)))
+    monkeypatch.setattr(backtest_view.st, "caption", lambda msg: events.append(("caption", msg)))
+    monkeypatch.setattr(backtest_view.st, "dataframe", lambda frame, **_kwargs: events.append(("dataframe", frame)))
+    monkeypatch.setattr(backtest_view.st, "form", lambda _name: _Ctx())
+    monkeypatch.setattr(backtest_view.st, "multiselect", lambda _label, options, **_kwargs: list(options))
+    monkeypatch.setattr(backtest_view.st, "slider", lambda _label, **_kwargs: 2)
+    monkeypatch.setattr(backtest_view.st, "number_input", lambda _label, **_kwargs: int(_kwargs.get("value", 1)))
+    monkeypatch.setattr(backtest_view.st, "form_submit_button", lambda _label: True)
+
+    report = BacktestReport(
+        results=[
+            BacktestResult(
+                model_id="ridge",
+                metrics={"fold_count": 1, "mae": 0.1},
+                folds=cast(
+                    list[application_dto.SerializableRow],
+                    cast(
+                        object,
+                        [
+                            {
+                                "fold_index": 1,
+                                "train_start": "2024-01-01",
+                                "train_end": "2024-06-01",
+                                "test_start": "2024-06-02",
+                                "test_end": "2024-07-01",
+                                "n_train": 100,
+                                "n_test": 20,
+                                "metrics": {"mae": 0.1},
+                            }
+                        ],
+                    ),
+                ),
+            )
+        ],
+        split_spec={"fold_count": 1},
+    )
+    monkeypatch.setattr(backtest_view, "_backtest_uc", lambda: SimpleNamespace(execute=lambda _req: report))
+    monkeypatch.setattr(
+        backtest_view.BacktestPresenter,
+        "format_model_metrics_frame",
+        staticmethod(lambda _report, *, label_lookup: pd.DataFrame([{"model": label_lookup["ridge"], "mae": 0.1}])),
+    )
+    monkeypatch.setattr(
+        backtest_view.BacktestPresenter,
+        "format_fold_frame",
+        staticmethod(lambda _result: pd.DataFrame([{"fold_index": 1, "metric_mae": 0.1}])),
+    )
+
+    backtest_view.render()
+
+    assert ("subheader", "Backtest summary by model") in events
+    assert ("subheader", "Fold-level details") in events
+    assert any(event[0] == "caption" and "Walk-forward folds evaluated" in str(event[1]) for event in events)
+    assert len([event for event in events if event[0] == "dataframe"]) >= 2
+    assert not [event for event in events if event[0] in {"warning", "error"}]
 
 

--- a/tests/unit/application/test_dto.py
+++ b/tests/unit/application/test_dto.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from finsight.application.dto import (
+    BacktestFoldSummary,
+    BacktestReport,
+    BacktestRequest,
     BacktestResult,
     CompareModelsRequest,
     CompareModelsResult,
@@ -133,6 +136,52 @@ def test_forecast_and_backtest_results_are_serializable() -> None:
 
     assert ForecastResult.from_dict(forecast_payload) == forecast
     assert BacktestResult.from_dict(backtest_payload) == backtest
+
+
+def test_backtest_request_roundtrip() -> None:
+    request = BacktestRequest(
+        model_ids=["naive_zero", "ridge"],
+        years=3,
+        end="2026-03-31",
+        interval="1d",
+        min_train_days=200,
+        test_window_days=30,
+        step_days=15,
+        max_folds=6,
+    )
+
+    assert BacktestRequest.from_dict(request.to_dict()) == request
+
+
+def test_backtest_report_roundtrip() -> None:
+    fold = BacktestFoldSummary(
+        fold_index=1,
+        train_start="2024-01-01",
+        train_end="2024-12-31",
+        test_start="2025-01-01",
+        test_end="2025-01-31",
+        n_train=252,
+        n_test=21,
+        metrics={"mae": 0.12, "rmse": 0.18},
+    )
+    report = BacktestReport(
+        results=[
+            BacktestResult(
+                model_id="ridge",
+                metrics={"mae": 0.11, "rmse": 0.17},
+                folds=[fold.to_dict()],
+            )
+        ],
+        dataset_spec=DatasetSpec(
+            tickers=("AAPL", "JPM"),
+            start_date="2024-01-01",
+            end_date="2026-03-31",
+            interval="1d",
+        ),
+        split_spec={"min_train_days": 252, "test_window_days": 21, "step_days": 21},
+    )
+
+    assert BacktestReport.from_dict(report.to_dict()) == report
 
 
 def test_train_model_result_is_constructible() -> None:

--- a/tests/unit/application/use_cases/test_backtest.py
+++ b/tests/unit/application/use_cases/test_backtest.py
@@ -34,6 +34,11 @@ class _StubFeatureStore:
         return self._feature_df.copy()
 
 
+class _NonDataFrameFeatureStore:
+    def build_feature_dataset(self, series_list: list[OHLCVSeries]) -> list[object]:
+        return list(series_list)
+
+
 class _StubModel:
     def __init__(self) -> None:
         self.calls: list[tuple[str, int, int]] = []
@@ -186,5 +191,144 @@ def test_backtest_rejects_unsupported_model_ids() -> None:
             )
         )
 
+
+def test_backtest_normalizes_training_tickers_and_uses_request_defaults() -> None:
+    fetch_stub = _StubFetchMarketData({"AAA": _make_series("AAA"), "BBB": _make_series("BBB")})
+    feature_store = _StubFeatureStore(_feature_frame())
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, fetch_stub)),
+        feature_store=cast(FeatureStorePort, cast(object, feature_store)),
+        model=cast(ModelPort, cast(object, _StubModel())),
+        training_tickers=(" aaa ", "bbb"),
+        default_interval="1wk",
+    )
+
+    report = use_case.execute(
+        application_dto.BacktestRequest(
+            model_ids=[" naive_zero "],
+            years=1,
+            end="2024-01-08",
+            interval=None,
+            min_train_days=4,
+            test_window_days=2,
+            step_days=2,
+            max_folds=1,
+        )
+    )
+
+    assert [call.ticker for call in fetch_stub.calls] == ["AAA", "BBB"]
+    assert {call.interval for call in fetch_stub.calls} == {"1wk"}
+    assert {call.include_summary for call in fetch_stub.calls} == {False}
+    assert report.dataset_spec is not None
+    assert report.dataset_spec.tickers == ("AAA", "BBB")
+    assert report.dataset_spec.start_date == "2023-01-09"
+    assert report.dataset_spec.end_date == "2024-01-08"
+    assert report.dataset_spec.interval == "1wk"
+    assert report.results[0].model_id == "naive_zero"
+    assert report.split_spec["max_folds"] == 1
+    assert report.split_spec["fold_count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("model_ids", "message"),
+    [
+        ([], "model_ids must contain at least one model id"),
+        (["naive_zero", " naive_zero "], "model_ids must be unique"),
+        (["naive_zero", " "], "model_ids must not contain empty values"),
+    ],
+)
+def test_backtest_rejects_invalid_model_id_lists(model_ids: list[str], message: str) -> None:
+    fetch_stub = _StubFetchMarketData({"AAA": _make_series("AAA")})
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, fetch_stub)),
+        feature_store=cast(FeatureStorePort, cast(object, _StubFeatureStore(_feature_frame()))),
+        model=cast(ModelPort, cast(object, _StubModel())),
+        training_tickers=("AAA",),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        use_case.execute(
+            application_dto.BacktestRequest(
+                model_ids=model_ids,
+                years=1,
+                end="2024-01-08",
+                min_train_days=4,
+                test_window_days=2,
+                step_days=2,
+            )
+        )
+
+
+def test_backtest_rejects_duplicate_configured_training_tickers() -> None:
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, _StubFetchMarketData({"AAA": _make_series("AAA")}))),
+        feature_store=cast(FeatureStorePort, cast(object, _StubFeatureStore(_feature_frame()))),
+        model=cast(ModelPort, cast(object, _StubModel())),
+        training_tickers=("AAA", " aaa "),
+    )
+
+    with pytest.raises(ValueError, match="Configured training tickers must not contain duplicates"):
+        use_case.execute(
+            application_dto.BacktestRequest(
+                model_ids=["naive_zero"],
+                years=1,
+                end="2024-01-08",
+                min_train_days=4,
+                test_window_days=2,
+                step_days=2,
+            )
+        )
+
+
+def test_backtest_rejects_non_dataframe_feature_dataset() -> None:
+    fetch_stub = _StubFetchMarketData({"AAA": _make_series("AAA")})
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, fetch_stub)),
+        feature_store=cast(FeatureStorePort, cast(object, _NonDataFrameFeatureStore())),
+        model=cast(ModelPort, cast(object, _StubModel())),
+        training_tickers=("AAA",),
+    )
+
+    with pytest.raises(TypeError, match="Feature store must return a pandas DataFrame"):
+        use_case.execute(
+            application_dto.BacktestRequest(
+                model_ids=["naive_zero"],
+                years=1,
+                end="2024-01-08",
+                min_train_days=4,
+                test_window_days=2,
+                step_days=2,
+            )
+        )
+
+
+def test_backtest_rejects_non_finite_fold_metrics() -> None:
+    class _NonFiniteMetricModel(_StubModel):
+        def evaluate(self, **_kwargs) -> ModelEvaluationResult:
+            return ModelEvaluationResult(
+                metrics={"mae": float("nan")},
+                predictions=pd.DataFrame(),
+                trained_artifact=object(),
+                model_metadata={"model_id": "naive_zero"},
+            )
+
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, _StubFetchMarketData({"AAA": _make_series("AAA")}))),
+        feature_store=cast(FeatureStorePort, cast(object, _StubFeatureStore(_feature_frame()))),
+        model=cast(ModelPort, cast(object, _NonFiniteMetricModel())),
+        training_tickers=("AAA",),
+    )
+
+    with pytest.raises(ValueError, match="must be finite"):
+        use_case.execute(
+            application_dto.BacktestRequest(
+                model_ids=["naive_zero"],
+                years=1,
+                end="2024-01-08",
+                min_train_days=4,
+                test_window_days=2,
+                step_days=2,
+            )
+        )
 
 

--- a/tests/unit/application/use_cases/test_backtest.py
+++ b/tests/unit/application/use_cases/test_backtest.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pandas as pd
+import pytest
+
+import finsight.application.dto as application_dto
+from finsight.application.use_cases.backtest import Backtest
+from finsight.application.use_cases.fetch_market_data import FetchMarketData
+from finsight.domain.entities import ModelEvaluationResult, OHLCVSeries
+from finsight.domain.ports import FeatureStorePort, ModelPort
+from finsight.domain.value_objects import DateRange, Interval, Ticker
+
+
+class _StubFetchMarketData:
+    def __init__(self, series_by_ticker: dict[str, OHLCVSeries]) -> None:
+        self._series_by_ticker = series_by_ticker
+        self.calls: list[application_dto.FetchMarketDataRequest] = []
+
+    def execute(self, request: application_dto.FetchMarketDataRequest) -> SimpleNamespace:
+        self.calls.append(request)
+        return SimpleNamespace(history=self._series_by_ticker[request.ticker])
+
+
+class _StubFeatureStore:
+    def __init__(self, feature_df: pd.DataFrame) -> None:
+        self._feature_df = feature_df
+        self.received_series_count = 0
+
+    def build_feature_dataset(self, series_list: list[OHLCVSeries]) -> pd.DataFrame:
+        self.received_series_count = len(series_list)
+        return self._feature_df.copy()
+
+
+class _StubModel:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int, int]] = []
+
+    def supported_model_types(self) -> tuple[str, ...]:
+        return ("naive_zero", "naive_mean")
+
+    def evaluate(
+        self,
+        *,
+        train_dataset: object,
+        test_dataset: object,
+        model_type: str,
+        target_column: str,
+        id_columns=("date", "ticker"),
+    ) -> ModelEvaluationResult:
+        train_df = cast(pd.DataFrame, train_dataset)
+        test_df = cast(pd.DataFrame, test_dataset)
+        self.calls.append((model_type, len(train_df), len(test_df)))
+
+        base = 0.1 if model_type == "naive_zero" else 0.2
+        mae = base + (len(test_df) / 100.0)
+        rmse = base + (len(train_df) / 100.0)
+        direction_accuracy = 0.5 + base
+
+        return ModelEvaluationResult(
+            metrics={
+                "mae": mae,
+                "rmse": rmse,
+                "direction_accuracy": direction_accuracy,
+            },
+            predictions=pd.DataFrame(),
+            trained_artifact=object(),
+            model_metadata={"model_id": model_type},
+        )
+
+
+def _make_series(ticker: str) -> OHLCVSeries:
+    dates = pd.date_range("2024-01-01", periods=12, freq="D")
+    closes = [100.0 + idx for idx in range(12)]
+    df = pd.DataFrame(
+        {
+            "Date": dates,
+            "Open": closes,
+            "High": closes,
+            "Low": closes,
+            "Close": closes,
+            "Volume": [1000 + idx for idx in range(12)],
+        }
+    )
+    return OHLCVSeries(
+        ticker=Ticker(ticker),
+        date_range=DateRange("2024-01-01", "2024-01-12"),
+        interval=Interval("1d"),
+        df=df,
+    )
+
+
+def _feature_frame() -> pd.DataFrame:
+    dates = pd.date_range("2024-01-01", periods=8, freq="D")
+    rows: list[dict[str, object]] = []
+    for ticker in ("AAA", "BBB"):
+        for idx, day in enumerate(dates):
+            rows.append(
+                {
+                    "date": day,
+                    "ticker": ticker,
+                    "ret_1d": float(idx) / 100.0,
+                    "mom_20d": float(idx) / 50.0,
+                    "target_ret_1d": float(idx) / 200.0,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_backtest_executes_multiple_models_and_aggregates_fold_metrics() -> None:
+    fetch_stub = _StubFetchMarketData({"AAA": _make_series("AAA"), "BBB": _make_series("BBB")})
+    feature_store = _StubFeatureStore(_feature_frame())
+    model = _StubModel()
+
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, fetch_stub)),
+        feature_store=cast(FeatureStorePort, cast(object, feature_store)),
+        model=cast(ModelPort, cast(object, model)),
+        training_tickers=("AAA", "BBB"),
+        default_interval="1d",
+    )
+
+    report = use_case.execute(
+        application_dto.BacktestRequest(
+            model_ids=["naive_zero", "naive_mean"],
+            years=1,
+            end="2024-01-08",
+            interval="1d",
+            min_train_days=4,
+            test_window_days=2,
+            step_days=2,
+        )
+    )
+
+    assert feature_store.received_series_count == 2
+    assert len(fetch_stub.calls) == 2
+    assert len(report.results) == 2
+    assert report.split_spec["name"] == "walk_forward"
+    assert report.split_spec["fold_count"] == 2
+
+    by_model = {row.model_id: row for row in report.results}
+    assert set(by_model.keys()) == {"naive_zero", "naive_mean"}
+
+    naive_zero = by_model["naive_zero"]
+    assert naive_zero.metrics["fold_count"] == 2
+    assert naive_zero.metrics["mae"] == pytest.approx(0.14)
+    assert naive_zero.metrics["rmse"] == pytest.approx(0.20)
+    assert naive_zero.metrics["direction_accuracy"] == pytest.approx(0.6)
+
+    assert len(naive_zero.folds) == 2
+    assert naive_zero.folds[0]["fold_index"] == 1
+    assert naive_zero.folds[0]["train_end"] == "2024-01-04"
+    assert naive_zero.folds[0]["test_start"] == "2024-01-05"
+    assert naive_zero.folds[0]["test_end"] == "2024-01-06"
+
+    naive_mean = by_model["naive_mean"]
+    assert naive_mean.metrics["fold_count"] == 2
+    assert naive_mean.metrics["mae"] == pytest.approx(0.24)
+    assert naive_mean.metrics["rmse"] == pytest.approx(0.30)
+    assert naive_mean.metrics["direction_accuracy"] == pytest.approx(0.7)
+
+    assert len(model.calls) == 4
+
+
+def test_backtest_rejects_unsupported_model_ids() -> None:
+    fetch_stub = _StubFetchMarketData({"AAA": _make_series("AAA")})
+    feature_store = _StubFeatureStore(_feature_frame())
+    use_case = Backtest(
+        fetch_market_data=cast(FetchMarketData, cast(object, fetch_stub)),
+        feature_store=cast(FeatureStorePort, cast(object, feature_store)),
+        model=cast(ModelPort, cast(object, _StubModel())),
+        training_tickers=("AAA",),
+    )
+
+    with pytest.raises(ValueError, match="Unsupported model id"):
+        use_case.execute(
+            application_dto.BacktestRequest(
+                model_ids=["ridge"],
+                years=1,
+                end="2024-01-08",
+                min_train_days=4,
+                test_window_days=2,
+                step_days=2,
+            )
+        )
+
+
+

--- a/tests/unit/bootstrap/test_container.py
+++ b/tests/unit/bootstrap/test_container.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from finsight.bootstrap import container as container_module
 from finsight.config.settings import Settings
+from finsight.application.use_cases.backtest import Backtest
 from finsight.application.use_cases.compare_models import CompareModels
 
 
@@ -13,6 +14,16 @@ def test_build_container_exposes_compare_models_use_case(monkeypatch) -> None:
 
     assert isinstance(app_container.compare_models, CompareModels)
     assert app_container.compare_models is app_container.compare_models
+
+
+def test_build_container_exposes_backtest_use_case(monkeypatch) -> None:
+    container_module.build_container.cache_clear()
+    monkeypatch.setattr(container_module, "get_settings", lambda: Settings())
+
+    app_container = container_module.build_container()
+
+    assert isinstance(app_container.backtest, Backtest)
+    assert app_container.backtest is app_container.backtest
 
 
 def test_build_container_exposes_hist_gbdt_in_router(monkeypatch) -> None:

--- a/tests/unit/infrastructure/features/test_policies.py
+++ b/tests/unit/infrastructure/features/test_policies.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 import pandas as pd
 import pytest
 
-from finsight.infrastructure.features import TimeSplitPolicy
+from finsight.infrastructure.features import TimeSplitPolicy, WalkForwardSplitPolicy
 
 
 def _to_iso_dates(series: pd.Series) -> list[str]:
@@ -151,4 +151,67 @@ def test_split_is_deterministically_sorted_from_unsorted_input() -> None:
         ("BBB", "2024-01-03"),
         ("BBB", "2024-01-04"),
     ]
+
+
+def test_walk_forward_generates_expected_fold_boundaries() -> None:
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=10, freq="D").tolist() * 2,
+            "ticker": ["AAA"] * 10 + ["BBB"] * 10,
+            "x": list(range(10)) + list(range(10)),
+            "target_ret_1d": [0.1] * 20,
+        }
+    )
+
+    policy = WalkForwardSplitPolicy(min_train_size=4, test_size=2, step_size=2)
+    folds = policy.split_frame(df)
+
+    assert [fold.fold_index for fold in folds] == [1, 2, 3]
+    assert [(fold.train_end.isoformat(), fold.test_start.isoformat(), fold.test_end.isoformat()) for fold in folds] == [
+        ("2024-01-04", "2024-01-05", "2024-01-06"),
+        ("2024-01-06", "2024-01-07", "2024-01-08"),
+        ("2024-01-08", "2024-01-09", "2024-01-10"),
+    ]
+    assert [len(fold.train_df) for fold in folds] == [8, 12, 16]
+    assert [len(fold.test_df) for fold in folds] == [4, 4, 4]
+
+
+def test_walk_forward_respects_max_folds() -> None:
+    df = pd.DataFrame(
+        {
+            "date": pd.date_range("2024-01-01", periods=12, freq="D"),
+            "ticker": ["AAA"] * 12,
+            "x": list(range(12)),
+            "target_ret_1d": [0.1] * 12,
+        }
+    )
+
+    policy = WalkForwardSplitPolicy(min_train_size=4, test_size=2, step_size=1, max_folds=2)
+    folds = policy.split_frame(df)
+
+    assert len(folds) == 2
+    assert [fold.fold_index for fold in folds] == [1, 2]
+
+
+def test_walk_forward_rejects_invalid_parameters_and_impossible_splits() -> None:
+    with pytest.raises(ValueError, match="min_train_size must be a positive integer"):
+        WalkForwardSplitPolicy(min_train_size=0, test_size=2, step_size=1)
+
+    with pytest.raises(ValueError, match="test_size must be a positive integer"):
+        WalkForwardSplitPolicy(min_train_size=2, test_size=0, step_size=1)
+
+    with pytest.raises(ValueError, match="step_size must be a positive integer"):
+        WalkForwardSplitPolicy(min_train_size=2, test_size=2, step_size=0)
+
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04"],
+            "ticker": ["AAA", "AAA", "AAA", "AAA"],
+            "x": [1.0, 2.0, 3.0, 4.0],
+            "target_ret_1d": [0.1, 0.2, 0.3, 0.4],
+        }
+    )
+    with pytest.raises(ValueError, match="cannot produce any fold"):
+        WalkForwardSplitPolicy(min_train_size=3, test_size=2, step_size=1).split_frame(df)
+
 


### PR DESCRIPTION
Introduce a new walk-forward backtest use case, including data classes for requests and reports, implementation with validation and metrics aggregation, and integration tests. Update the application container to expose the backtest use case and add a dedicated page for walk-forward backtesting with model selection and results display.