### PR TITLE
Chore/issues/48 add additional evaluation metrics

### DIFF
--- a/src/finsight/adapters/web_streamlit/views/compare.py
+++ b/src/finsight/adapters/web_streamlit/views/compare.py
@@ -6,13 +6,14 @@ from finsight.application.dto import CompareModelsRequest
 from finsight.adapters.web_streamlit.presenters import ComparisonPresenter
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 
 
 _SETTINGS = get_settings()
 _METRIC_LABELS = {
     METRIC_MAE: "Mean Absolute Error (lower is better)",
     METRIC_RMSE: "Root Mean Squared Error (lower is better)",
+    METRIC_R2: "R² Score (higher is better)",
     METRIC_DIRECTION_ACCURACY: "Direction Accuracy (higher is better)",
 }
 
@@ -28,8 +29,8 @@ def render():
         "Build a deterministic leaderboard from the latest saved model runs. "
         "Ranking follows a fixed metric priority among the metrics you select, then model ID, then run ID.")
     st.info(
-        "Metric direction defaults: MAE/RMSE are ranked lower-is-better, while Direction Accuracy is ranked higher-is-better. "
-        "Use Ranking metrics to include or exclude metrics. Priority remains MAE -> RMSE -> Direction Accuracy."
+        "Metric direction defaults: MAE/RMSE are ranked lower-is-better, while R² and Direction Accuracy are ranked higher-is-better. "
+        "Use Ranking metrics to include or exclude metrics. Default priority is MAE -> RMSE -> R² -> Direction Accuracy."
     )
 
     model_defaults = _SETTINGS.model_defaults
@@ -40,7 +41,8 @@ def render():
         st.warning("No training-enabled models are configured.")
         return
 
-    default_rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY]
+    ranking_metrics = [METRIC_MAE, METRIC_RMSE, METRIC_R2, METRIC_DIRECTION_ACCURACY]
+    default_rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_R2, METRIC_DIRECTION_ACCURACY]
 
     with st.form("compare_models_form"):
         selected_model_ids = st.multiselect(
@@ -51,7 +53,7 @@ def render():
         )
         selected_rank_by = st.multiselect(
             "Ranking metrics",
-            default_rank_by,
+            ranking_metrics,
             default=default_rank_by,
             format_func=lambda metric_name: _METRIC_LABELS.get(metric_name, metric_name),
         )

--- a/src/finsight/application/dto.py
+++ b/src/finsight/application/dto.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from finsight.domain.entities import OHLCVSeries, StockSummary
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 
 MetricValue = float | int | str
 SerializableScalar = str | int | float | bool | None
@@ -360,7 +360,7 @@ class ModelComparisonRow:
 class CompareModelsRequest:
     model_ids: list[str]
     artifacts_dir: str = "artifacts/runs"
-    rank_by: list[str] = field(default_factory=lambda: [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY])
+    rank_by: list[str] = field(default_factory=lambda: [METRIC_MAE, METRIC_RMSE, METRIC_R2, METRIC_DIRECTION_ACCURACY])
     metric_directions: dict[str, str] = field(default_factory=dict)
     use_best_runs: bool = False
 
@@ -384,7 +384,7 @@ class CompareModelsRequest:
         if isinstance(raw_rank_by, (list, tuple)):
             rank_by = [str(item) for item in raw_rank_by]
         else:
-            rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY]
+            rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_R2, METRIC_DIRECTION_ACCURACY]
 
         metric_directions: dict[str, str] = {}
         if isinstance(raw_metric_directions, Mapping):
@@ -445,7 +445,7 @@ class CompareModelsResult:
         if isinstance(raw_rank_by, (list, tuple)):
             rank_by = [str(item) for item in raw_rank_by]
         else:
-            rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY]
+            rank_by = [METRIC_MAE, METRIC_RMSE, METRIC_R2, METRIC_DIRECTION_ACCURACY]
 
         raw_metric_directions = payload.get("metric_directions", {})
         metric_directions: dict[str, str] = {}

--- a/src/finsight/cli/main.py
+++ b/src/finsight/cli/main.py
@@ -9,7 +9,7 @@ import pandas as pd
 from finsight.application.dto import CompareModelsRequest, ForecastRequest, TrainModelRequest
 from finsight.bootstrap.container import build_container
 from finsight.config.settings import get_settings
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -52,10 +52,10 @@ def _build_parser() -> argparse.ArgumentParser:
     compare_parser.add_argument(
         "--rank-by",
         nargs="+",
-        default=[METRIC_MAE, METRIC_RMSE, METRIC_DIRECTION_ACCURACY],
+        default=[METRIC_MAE, METRIC_RMSE, METRIC_R2, METRIC_DIRECTION_ACCURACY],
         help=(
             "Ordered comparison metrics used for ranking "
-            f"(defaults: {METRIC_MAE}, {METRIC_RMSE}, {METRIC_DIRECTION_ACCURACY})"
+            f"(defaults: {METRIC_MAE}, {METRIC_RMSE}, {METRIC_R2}, {METRIC_DIRECTION_ACCURACY})"
         ),
     )
     compare_parser.add_argument(
@@ -118,6 +118,7 @@ def _run_train(args: argparse.Namespace) -> int:
             "  "
             f"MAE={float(model_metrics[METRIC_MAE]):.6f} "
             f"RMSE={float(model_metrics[METRIC_RMSE]):.6f} "
+            f"R2={float(model_metrics[METRIC_R2]):.6f} "
             f"DirectionAcc={float(model_metrics[METRIC_DIRECTION_ACCURACY]):.4f}"
         )
 

--- a/src/finsight/domain/metrics.py
+++ b/src/finsight/domain/metrics.py
@@ -5,11 +5,13 @@ from collections.abc import Sequence
 
 METRIC_MAE = "mae"
 METRIC_RMSE = "rmse"
+METRIC_R2 = "r2"
 METRIC_DIRECTION_ACCURACY = "direction_accuracy"
 
 SUPPORTED_METRIC_NAMES = (
     METRIC_MAE,
     METRIC_RMSE,
+    METRIC_R2,
     METRIC_DIRECTION_ACCURACY,
 )
 
@@ -23,6 +25,22 @@ def root_mean_squared_error(y_true: Sequence[float], y_pred: Sequence[float]) ->
     count = _validate_input_lengths(y_true, y_pred)
     mse = sum((float(a) - float(b)) ** 2 for a, b in zip(y_true, y_pred)) / count
     return float(math.sqrt(mse))
+
+
+def r2_score(y_true: Sequence[float], y_pred: Sequence[float]) -> float:
+    count = _validate_input_lengths(y_true, y_pred)
+
+    true_values = [float(value) for value in y_true]
+    pred_values = [float(value) for value in y_pred]
+    mean_true = sum(true_values) / count
+
+    ss_res = sum((true - pred) ** 2 for true, pred in zip(true_values, pred_values))
+    ss_tot = sum((true - mean_true) ** 2 for true in true_values)
+
+    if ss_tot == 0.0:
+        return 1.0 if ss_res == 0.0 else 0.0
+
+    return float(1.0 - (ss_res / ss_tot))
 
 
 def direction_accuracy(
@@ -48,11 +66,13 @@ def forecast_metrics(
     count = _validate_input_lengths(y_true, y_pred)
     abs_error_sum = 0.0
     squared_error_sum = 0.0
+    true_values: list[float] = []
     matching_directions = 0
 
     for true_raw, pred_raw in zip(y_true, y_pred):
         true_val = float(true_raw)
         pred_val = float(pred_raw)
+        true_values.append(true_val)
         error = true_val - pred_val
         abs_error_sum += abs(error)
         squared_error_sum += error ** 2
@@ -61,6 +81,7 @@ def forecast_metrics(
     return {
         METRIC_MAE: float(abs_error_sum / count),
         METRIC_RMSE: float(math.sqrt(squared_error_sum / count)),
+        METRIC_R2: r2_score(true_values, y_pred),
         METRIC_DIRECTION_ACCURACY: float(matching_directions / count),
     }
 

--- a/src/finsight/infrastructure/ml/model_ranker.py
+++ b/src/finsight/infrastructure/ml/model_ranker.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Mapping
+from typing import Any
 
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 
 
 # Default metric directions: asc = lower is better, desc = higher is better
 _DEFAULT_DIRECTION_BY_METRIC = {
     METRIC_MAE: "asc",
     METRIC_RMSE: "asc",
+    METRIC_R2: "desc",
     METRIC_DIRECTION_ACCURACY: "desc",
 }
 

--- a/src/finsight/infrastructure/ml/run_registry.py
+++ b/src/finsight/infrastructure/ml/run_registry.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from finsight.application.dto import RegistrySnapshot, RunSummary
+from finsight.domain.metrics import METRIC_MAE, METRIC_R2
 from finsight.domain.ports import RunRegistryPort
 from finsight.infrastructure.ml.model_ranker import ModelRanker
 
@@ -29,6 +30,7 @@ class LocalFileRunRegistry(RunRegistryPort):
     """
 
     REGISTRY_FILENAME = "registry.json"
+    _REGISTRY_PRIORITY_METRICS = (METRIC_MAE, METRIC_R2)
 
     def __init__(self, *, supported_model_ids: tuple[str, ...] | None = None) -> None:
         """
@@ -77,7 +79,7 @@ class LocalFileRunRegistry(RunRegistryPort):
         Record a completed training run.
 
         Loads current registry, compares new run against current best for that model,
-        updates if new is better (by MAE metric), and saves registry atomically.
+        updates if new is better (by MAE, then R² when available), and saves registry atomically.
         """
         model_id = run_summary.model_id
         artifact_root_path = Path(artifact_root)
@@ -104,18 +106,25 @@ class LocalFileRunRegistry(RunRegistryPort):
         should_update = True
 
         if current_best is not None and isinstance(current_best, dict):
-            # Compare using MAE metric (primary ranking metric)
-            ranker = ModelRanker(
-                rank_by=["mae"],
-                metric_directions={"mae": "asc"},
-            )
-
             new_metrics = run_summary.metrics
             current_metrics = current_best.get("metrics", {})
 
-            # is_better returns False if any metric is missing
-            if not ranker.is_better(new_metrics, current_metrics):
+            rank_by = [
+                metric_name
+                for metric_name in self._REGISTRY_PRIORITY_METRICS
+                if metric_name in new_metrics and metric_name in current_metrics
+            ]
+
+            if not rank_by:
                 should_update = False
+            else:
+                ranker = ModelRanker(
+                    rank_by=rank_by,
+                    metric_directions={METRIC_MAE: "asc", METRIC_R2: "desc"},
+                )
+
+                if not ranker.is_better(new_metrics, current_metrics):
+                    should_update = False
 
         # Update best run for this model if new is better
         if should_update:

--- a/tests/unit/adapters/web_streamlit/test_compare.py
+++ b/tests/unit/adapters/web_streamlit/test_compare.py
@@ -14,18 +14,18 @@ def test_build_comparison_frame_orders_columns_and_applies_labels() -> None:
                 rank=1,
                 model_id="ridge",
                 run_id="2026-04-12T120000Z__ridge",
-                metrics={"mae": 0.09, "rmse": 0.18, "direction_accuracy": 0.83, "extra": 7},
-                sort_key=(0.09, 0.18, -0.83, "ridge", "2026-04-12T120000Z__ridge"),
+                metrics={"mae": 0.09, "rmse": 0.18, "r2": 0.91, "direction_accuracy": 0.83, "extra": 7},
+                sort_key=(0.09, 0.18, -0.91, -0.83, "ridge", "2026-04-12T120000Z__ridge"),
             )
         ],
-        rank_by=["mae", "rmse", "direction_accuracy"],
-        metric_directions={"mae": "asc", "rmse": "asc", "direction_accuracy": "desc"},
+        rank_by=["mae", "rmse", "r2", "direction_accuracy"],
+        metric_directions={"mae": "asc", "rmse": "asc", "r2": "desc", "direction_accuracy": "desc"},
     )
 
     frame = ComparisonPresenter.format_leaderboard_frame(result, label_lookup={"ridge": "Ridge Regression"})
 
     assert isinstance(frame, pd.DataFrame)
-    assert list(frame.columns) == ["rank", "model", "model_id", "run_id", "mae", "rmse", "direction_accuracy", "extra"]
+    assert list(frame.columns) == ["rank", "model", "model_id", "run_id", "mae", "rmse", "r2", "direction_accuracy", "extra"]
     assert frame.iloc[0]["model"] == "Ridge Regression"
     assert frame.iloc[0]["rank"] == 1
     assert frame.iloc[0]["extra"] == 7

--- a/tests/unit/application/test_dto.py
+++ b/tests/unit/application/test_dto.py
@@ -92,8 +92,8 @@ def test_compare_models_request_and_result_roundtrip() -> None:
     request = CompareModelsRequest(
         model_ids=["naive_zero", "ridge"],
         artifacts_dir="artifacts/runs",
-        rank_by=["mae", "direction_accuracy"],
-        metric_directions={"direction_accuracy": "desc"},
+        rank_by=["mae", "r2", "direction_accuracy"],
+        metric_directions={"r2": "desc", "direction_accuracy": "desc"},
         use_best_runs=True,
     )
     result = CompareModelsResult(
@@ -102,16 +102,22 @@ def test_compare_models_request_and_result_roundtrip() -> None:
                 rank=1,
                 model_id="ridge",
                 run_id="2026-04-12T120000Z__ridge",
-                metrics={"mae": 0.09, "direction_accuracy": 0.87},
-                sort_key=(0.09, -0.87, "ridge", "2026-04-12T120000Z__ridge"),
+                metrics={"mae": 0.09, "r2": 0.92, "direction_accuracy": 0.87},
+                sort_key=(0.09, -0.92, -0.87, "ridge", "2026-04-12T120000Z__ridge"),
             )
         ],
-        rank_by=["mae", "direction_accuracy"],
-        metric_directions={"mae": "asc", "direction_accuracy": "desc"},
+        rank_by=["mae", "r2", "direction_accuracy"],
+        metric_directions={"mae": "asc", "r2": "desc", "direction_accuracy": "desc"},
     )
 
     assert CompareModelsRequest.from_dict(request.to_dict()) == request
     assert CompareModelsResult.from_dict(result.to_dict()) == result
+
+
+def test_compare_models_request_defaults_include_r2_priority() -> None:
+    request = CompareModelsRequest(model_ids=["naive_zero"])
+
+    assert request.rank_by == ["mae", "rmse", "r2", "direction_accuracy"]
 
 
 def test_forecast_and_backtest_results_are_serializable() -> None:

--- a/tests/unit/application/use_cases/test_compare_models.py
+++ b/tests/unit/application/use_cases/test_compare_models.py
@@ -6,7 +6,7 @@ import pytest
 
 from finsight.application.dto import CompareModelsRequest, ModelRunArtifacts, RegistrySnapshot
 from finsight.application.use_cases.compare_models import CompareModels
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 from finsight.domain.ports import ModelRegistryPort, RunRegistryPort
 
 
@@ -113,6 +113,31 @@ def test_compare_models_ranks_by_multiple_metrics_with_expected_direction() -> N
         ("artifacts/runs", "2026-04-11T120000Z__alpha"),
         ("artifacts/runs", "2026-04-12T120000Z__beta"),
     ]
+
+
+def test_compare_models_ranks_by_r2_in_descending_order() -> None:
+    registry = _StubRegistry(
+        artifacts_by_model_id={
+            "alpha": _make_model_run_artifacts(
+                model_id="alpha",
+                run_id="2026-04-11T120000Z__alpha",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.22, METRIC_R2: 0.81},
+            ),
+            "beta": _make_model_run_artifacts(
+                model_id="beta",
+                run_id="2026-04-12T120000Z__beta",
+                metrics={METRIC_MAE: 0.10, METRIC_RMSE: 0.22, METRIC_R2: 0.90},
+            ),
+        }
+    )
+
+    result = CompareModels(model_registry=registry).execute(
+        CompareModelsRequest(model_ids=["alpha", "beta"], rank_by=[METRIC_R2])
+    )
+
+    assert [row.model_id for row in result.rows] == ["beta", "alpha"]
+    assert result.rank_by == [METRIC_R2]
+    assert result.metric_directions == {METRIC_R2: "desc"}
 
 
 def test_compare_models_uses_model_id_as_deterministic_tie_break() -> None:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -4,7 +4,7 @@ import json
 import finsight.cli.main as cli_main
 from finsight.cli.main import _build_parser, _run_train
 from finsight.application.dto import CompareModelsResult, ForecastResult, ModelComparisonRow
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 from finsight.config.settings import ModelCatalogEntry, ModelDefaults, Settings, TickerCatalogSettings
 
 
@@ -35,12 +35,20 @@ def test_compare_parser_accepts_compare_model_ids_and_rank_by() -> None:
     parser = _build_parser()
 
     args = parser.parse_args(
-        ["compare", "--model-ids", "naive_zero", "ridge", "--rank-by", "mae", "direction_accuracy"]
+        ["compare", "--model-ids", "naive_zero", "ridge", "--rank-by", "mae", "r2", "direction_accuracy"]
     )
 
     assert args.command == "compare"
     assert args.model_ids == ["naive_zero", "ridge"]
-    assert args.rank_by == ["mae", "direction_accuracy"]
+    assert args.rank_by == ["mae", "r2", "direction_accuracy"]
+
+
+def test_compare_parser_defaults_include_r2_in_priority() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["compare"])
+
+    assert args.rank_by == ["mae", "rmse", "r2", "direction_accuracy"]
 
 
 def test_forecast_parser_accepts_required_args() -> None:
@@ -252,6 +260,7 @@ def test_run_train_prints_metrics_using_canonical_metric_keys(monkeypatch, capsy
                         "naive_zero": {
                             METRIC_MAE: 0.1,
                             METRIC_RMSE: 0.2,
+                            METRIC_R2: 0.88,
                             METRIC_DIRECTION_ACCURACY: 0.75,
                         }
                     },
@@ -269,7 +278,7 @@ def test_run_train_prints_metrics_using_canonical_metric_keys(monkeypatch, capsy
     captured = capsys.readouterr().out
     assert exit_code == 0
     assert "[naive_zero] run_dir=artifacts/runs/example" in captured
-    assert "MAE=0.100000 RMSE=0.200000 DirectionAcc=0.7500" in captured
+    assert "MAE=0.100000 RMSE=0.200000 R2=0.880000 DirectionAcc=0.7500" in captured
 
 
 def test_run_train_handles_validation_error(monkeypatch, capsys) -> None:

--- a/tests/unit/domain/test_metrics.py
+++ b/tests/unit/domain/test_metrics.py
@@ -5,11 +5,13 @@ import pytest
 from finsight.domain.metrics import (
     METRIC_DIRECTION_ACCURACY,
     METRIC_MAE,
+    METRIC_R2,
     METRIC_RMSE,
     SUPPORTED_METRIC_NAMES,
     direction_accuracy,
     forecast_metrics,
     mean_absolute_error,
+    r2_score,
     root_mean_squared_error,
 )
 
@@ -27,6 +29,18 @@ def test_root_mean_squared_error() -> None:
 
     expected_rmse = math.sqrt((0.01 + 0.01 + 0.01) / 3)
     assert root_mean_squared_error(y_true, y_pred) == pytest.approx(expected_rmse)
+
+
+def test_r2_score() -> None:
+    y_true = [3.0, -0.5, 2.0, 7.0]
+    y_pred = [2.5, 0.0, 2.0, 8.0]
+
+    assert r2_score(y_true, y_pred) == pytest.approx(0.9486081370449679)
+
+
+def test_r2_score_handles_constant_targets() -> None:
+    assert r2_score([1.0, 1.0, 1.0], [1.0, 1.0, 1.0]) == pytest.approx(1.0)
+    assert r2_score([1.0, 1.0, 1.0], [1.0, 1.0, 2.0]) == pytest.approx(0.0)
 
 
 def test_direction_accuracy_with_default_threshold() -> None:
@@ -53,6 +67,7 @@ def test_forecast_metrics_returns_canonical_metric_keys() -> None:
     assert tuple(metrics.keys()) == SUPPORTED_METRIC_NAMES
     assert metrics[METRIC_MAE] == pytest.approx(0.10)
     assert metrics[METRIC_RMSE] == pytest.approx(math.sqrt((0.01 + 0.01 + 0.01) / 3))
+    assert metrics[METRIC_R2] == pytest.approx(0.7631578947368421)
     assert metrics[METRIC_DIRECTION_ACCURACY] == pytest.approx(2 / 3)
 
 

--- a/tests/unit/infrastructure/ml/test_model_ranker.py
+++ b/tests/unit/infrastructure/ml/test_model_ranker.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pytest
+from typing import cast
 
-from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_RMSE
+from finsight.domain.metrics import METRIC_DIRECTION_ACCURACY, METRIC_MAE, METRIC_R2, METRIC_RMSE
 from finsight.infrastructure.ml.model_ranker import ModelRanker
 
 
@@ -62,6 +63,10 @@ class TestGetDirection:
         ranker = ModelRanker(rank_by=[METRIC_DIRECTION_ACCURACY])
         assert ranker.get_direction(METRIC_DIRECTION_ACCURACY) == "desc"
 
+    def test_get_direction_returns_default_for_r2(self) -> None:
+        ranker = ModelRanker(rank_by=[METRIC_R2])
+        assert ranker.get_direction(METRIC_R2) == "desc"
+
     def test_get_direction_defaults_to_asc_for_unknown_metric(self) -> None:
         ranker = ModelRanker(rank_by=["unknown_metric"])
         assert ranker.get_direction("unknown_metric") == "asc"
@@ -115,6 +120,12 @@ class TestIsBetter:
         ranker = ModelRanker(rank_by=[METRIC_DIRECTION_ACCURACY])
         new_metrics = {METRIC_DIRECTION_ACCURACY: 0.90}
         current_metrics = {METRIC_DIRECTION_ACCURACY: 0.80}
+        assert ranker.is_better(new_metrics, current_metrics) is True
+
+    def test_is_better_with_higher_r2(self) -> None:
+        ranker = ModelRanker(rank_by=[METRIC_R2])
+        new_metrics = {METRIC_R2: 0.92}
+        current_metrics = {METRIC_R2: 0.89}
         assert ranker.is_better(new_metrics, current_metrics) is True
 
     def test_is_better_with_lower_direction_accuracy_is_false(self) -> None:
@@ -180,6 +191,12 @@ class TestComputeSortKey:
         # For descending, metric gets negated
         assert sort_key[0] == -0.85
 
+    def test_compute_sort_key_normalizes_r2_as_descending(self) -> None:
+        ranker = ModelRanker(rank_by=[METRIC_R2])
+        metrics = {METRIC_R2: 0.91}
+        sort_key = ranker.compute_sort_key(metrics, model_id="test", run_id="run")
+        assert sort_key[0] == -0.91
+
     def test_compute_sort_key_with_multiple_metrics(self) -> None:
         ranker = ModelRanker(rank_by=[METRIC_MAE, METRIC_RMSE])
         metrics = {METRIC_MAE: 0.10, METRIC_RMSE: 0.20}
@@ -196,8 +213,8 @@ class TestComputeSortKey:
 
     def test_compute_sort_key_coerces_numeric_strings(self) -> None:
         ranker = ModelRanker(rank_by=[METRIC_MAE])
-        metrics = {METRIC_MAE: "0.123"}
-        sort_key = ranker.compute_sort_key(metrics, model_id="test", run_id="run")
+        metrics: dict[str, float | str] = {METRIC_MAE: "0.123"}
+        sort_key = ranker.compute_sort_key(cast(dict[str, float], metrics), model_id="test", run_id="run")
         assert sort_key[0] == 0.123
 
 

--- a/tests/unit/infrastructure/ml/test_run_registry.py
+++ b/tests/unit/infrastructure/ml/test_run_registry.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from finsight.application.dto import RunSummary
+from finsight.domain.metrics import METRIC_MAE, METRIC_R2
 from finsight.infrastructure.ml.run_registry import LocalFileRunRegistry
 
 
@@ -130,6 +130,37 @@ class TestLocalFileRunRegistry:
 
         assert data["best_ridge"]["run_id"] == "2026-05-16T120000Z__ridge"
         assert data["best_ridge"]["metrics"]["mae"] == 0.100
+
+    def test_record_completed_run_uses_r2_as_secondary_priority(self, temp_artifact_dir: str) -> None:
+        """When MAE is tied, the better R² score should win."""
+        Path(temp_artifact_dir).mkdir(parents=True, exist_ok=True)
+
+        initial_data = {
+            "updated_at": "2026-05-16T110000Z",
+            "best_ridge": {
+                "run_id": "2026-05-16T110000Z__ridge",
+                "created_at": "2026-05-16T11:00:00Z",
+                "metrics": {METRIC_MAE: 0.100, METRIC_R2: 0.50},
+            },
+        }
+        registry_path = Path(temp_artifact_dir) / "registry.json"
+        registry_path.write_text(json.dumps(initial_data))
+
+        registry = LocalFileRunRegistry()
+        new_run = RunSummary(
+            run_id="2026-05-16T120000Z__ridge",
+            model_id="ridge",
+            created_at="2026-05-16T12:00:00Z",
+            metrics={METRIC_MAE: 0.100, METRIC_R2: 0.70},
+        )
+
+        registry.record_completed_run(artifact_root=temp_artifact_dir, run_summary=new_run)
+
+        with registry_path.open("r") as f:
+            data = json.load(f)
+
+        assert data["best_ridge"]["run_id"] == "2026-05-16T120000Z__ridge"
+        assert data["best_ridge"]["metrics"][METRIC_R2] == 0.70
 
     def test_record_completed_run_worse_run_does_not_update(self, temp_artifact_dir: str) -> None:
         """When new run is worse, registry is not updated."""


### PR DESCRIPTION
This pull request adds support for the R² metric (`r2`) throughout the Finsight codebase, making it a first-class metric for model evaluation and ranking. The changes ensure that R² is calculated, displayed, and prioritized alongside existing metrics (MAE, RMSE, Direction Accuracy) in both the application logic and user interfaces. Default ranking and metric direction settings are updated to include R², and relevant tests are updated or added to reflect these changes.

**Metric and Ranking Enhancements:**

* Added `METRIC_R2` as a supported metric in `metrics.py`, implemented the `r2_score` function, and included R² in the output of `forecast_metrics`. 
* Updated all default ranking metric lists and metric direction mappings to include R², ensuring it is used and prioritized after MAE and RMSE but before Direction Accuracy.

**Model Registry and Ranking Logic:**

* Modified the model registry to consider R² as a secondary priority metric (after MAE) when recording completed runs, updating the logic to compare runs using both MAE and R² when available. 
**User Interface and CLI:**

* Updated the Streamlit comparison view and CLI to display, accept, and default to using R² in ranking metrics, including label updates and help text. 

**Testing:**

* Updated and added tests to validate the correct handling, display, and defaulting of R² in ranking and comparison workflows, including roundtrip serialization and CLI argument parsing.

These changes collectively ensure that R² is fully integrated into the model evaluation pipeline and user experience.