### PR TITLE
feat: Chapter 5 dissertation scripts (single cutoff + walk-forward)

### DIFF
--- a/scripts/dissertation/01_run_all_training.sh
+++ b/scripts/dissertation/01_run_all_training.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Script 1 — Single-Cutoff Training & Leaderboard
+# ==============================================================================
+# Trains all five models with a fixed train/test split (cutoff 2024-01-01)
+# and produces a CLI leaderboard. Walk-forward training is handled by Script 02.
+#
+# Run from repo root:
+#   bash scripts/dissertation/01_run_all_training.sh
+# ==============================================================================
+set -euo pipefail
+
+CUTOFF="2024-01-01"
+END="2024-12-31"
+YEARS=3
+ARTIFACTS_DIR="artifacts/runs"
+DISS_DIR="artifacts/dissertation"
+MODELS="naive_zero naive_mean ridge hist_gbdt xgboost"
+
+mkdir -p "$DISS_DIR"
+
+# ── Step 1: Train all models ─────────────────────────────────────────────────
+echo "============================================================"
+echo " Step 1: Single-Cutoff Training"
+echo "   cutoff=$CUTOFF  end=$END  years=$YEARS"
+echo "   models: $MODELS"
+echo "============================================================"
+echo ""
+
+finsight train \
+    --cutoff "$CUTOFF" \
+    --years "$YEARS" \
+    --end "$END" \
+    --model-types $MODELS \
+    --artifacts-dir "$ARTIFACTS_DIR"
+
+echo ""
+
+# ── Step 2: Leaderboard ─────────────────────────────────────────────────────
+echo "============================================================"
+echo " Step 2: Model Comparison Leaderboard"
+echo "============================================================"
+echo ""
+
+finsight compare \
+    --model-ids $MODELS \
+    --rank-by mae rmse direction_accuracy \
+    --artifacts-dir "$ARTIFACTS_DIR" \
+    | tee "$DISS_DIR/leaderboard.txt"
+
+echo ""
+echo "Leaderboard saved to $DISS_DIR/leaderboard.txt"
+echo "Single-cutoff training complete. Run Script 02 next."

--- a/scripts/dissertation/02_per_stock_metrics.py
+++ b/scripts/dissertation/02_per_stock_metrics.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Script 2 — Per-Stock Metrics: Single Cutoff + Walk-Forward
+===========================================================
+Part 1  Uses the application layer (build_container / TrainModelRequest) to
+        train all five models with cutoff=2024-01-01, then computes MAE, RMSE
+        and Direction Accuracy for every model × ticker pair.
+
+Part 2  Runs expanding-window walk-forward validation on the same 3-year data
+        set, collects per-ticker metrics averaged across folds, and saves the
+        walk-forward test predictions for Script 03.
+
+Outputs
+-------
+artifacts/dissertation/per_stock_metrics.csv       — single-cutoff results
+artifacts/dissertation/per_stock_metrics_wf.csv    — walk-forward results
+artifacts/dissertation/wf_predictions/<model>.csv  — walk-forward predictions
+
+Run from repo root:
+    python scripts/dissertation/02_per_stock_metrics.py
+"""
+from __future__ import annotations
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+# Ensure finsight is importable even without pip install -e .
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import pandas as pd
+
+from finsight.application.dto import FetchMarketDataRequest, TrainModelRequest
+from finsight.bootstrap.container import build_container
+from finsight.domain.metrics import forecast_metrics
+from finsight.infrastructure.features.feature_store import PandasFeatureStore
+from finsight.infrastructure.features.policies import WalkForwardSplitPolicy
+from finsight.infrastructure.ml.sklearn import (
+    HistGradientBoostingModel,
+    LinearSklearnModel,
+    NaiveBaselineModel,
+    SklearnModelRouter,
+    XGBoostModel,
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Experimental conditions (shared across all scripts)
+# ═══════════════════════════════════════════════════════════════════════════════
+TICKERS = ["AAPL", "JPM", "XOM", "KO", "TSLA"]
+MODEL_IDS = ["naive_zero", "naive_mean", "ridge", "hist_gbdt", "xgboost"]
+CUTOFF_DATE = "2024-01-01"
+YEARS = 3
+END_DATE = "2024-12-31"
+ARTIFACTS_DIR = "artifacts/runs"
+TARGET_COLUMN = "target_ret_1d"
+
+# Walk-forward hyper-parameters
+WF_MIN_TRAIN_DAYS = 504  # ≈ 2 years of trading days → test period ≈ 2024
+WF_TEST_WINDOW = 21  # ≈ 1 month
+WF_STEP_DAYS = 21  # monthly non-overlapping steps
+
+# Output paths
+OUTPUT_DIR = Path("artifacts/dissertation")
+WF_PRED_DIR = OUTPUT_DIR / "wf_predictions"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+def _per_ticker_metrics(
+    preds: pd.DataFrame,
+    model_id: str,
+) -> list[dict[str, object]]:
+    """Compute MAE/RMSE/direction_accuracy per ticker from a predictions DF."""
+    rows: list[dict[str, object]] = []
+    for ticker in TICKERS:
+        tp = preds[preds["ticker"] == ticker]
+        if tp.empty:
+            continue
+        m = forecast_metrics(y_true=tp["y_true"].tolist(), y_pred=tp["y_pred"].tolist())
+        rows.append(
+            {
+                "ticker": ticker,
+                "model_id": model_id,
+                "mae": m["mae"],
+                "rmse": m["rmse"],
+                "direction_accuracy": m["direction_accuracy"],
+            }
+        )
+    return rows
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    WF_PRED_DIR.mkdir(parents=True, exist_ok=True)
+
+    container = build_container()
+
+    # ── Part 1: Single Cutoff ────────────────────────────────────────────────
+    print("=" * 70)
+    print("PART 1: Single-Cutoff Evaluation  (cutoff={})".format(CUTOFF_DATE))
+    print("=" * 70)
+
+    train_result = container.train_model.execute(
+        TrainModelRequest(
+            cutoff_date=CUTOFF_DATE,
+            years=YEARS,
+            end=END_DATE,
+            model_types=MODEL_IDS,
+            artifacts_dir=ARTIFACTS_DIR,
+        )
+    )
+
+    sc_rows: list[dict[str, object]] = []
+    for model_id in MODEL_IDS:
+        run_dir = train_result.run_dirs[model_id]
+        preds = pd.read_csv(Path(run_dir) / "predictions.csv")
+        preds["date"] = pd.to_datetime(preds["date"])
+        sc_rows.extend(_per_ticker_metrics(preds, model_id))
+
+    sc_df = pd.DataFrame(sc_rows)
+    sc_df.to_csv(OUTPUT_DIR / "per_stock_metrics.csv", index=False)
+
+    print("\nSingle-Cutoff Per-Stock Metrics:")
+    print(sc_df.to_string(index=False))
+    print(f"\nSaved → {OUTPUT_DIR / 'per_stock_metrics.csv'}")
+
+    # ── Part 2: Walk-Forward ─────────────────────────────────────────────────
+    print("\n" + "=" * 70)
+    print(
+        "PART 2: Walk-Forward Validation  "
+        f"(min_train={WF_MIN_TRAIN_DAYS}, window={WF_TEST_WINDOW}, step={WF_STEP_DAYS})"
+    )
+    print("=" * 70)
+
+    # Fetch data for all tickers (same date range as training)
+    end_d = date.fromisoformat(END_DATE)
+    start_d = end_d - timedelta(days=(YEARS * 365) - 1)
+
+    print(f"\nFetching data: {start_d} → {end_d}")
+    series_list = []
+    for ticker in TICKERS:
+        result = container.fetch_market_data.execute(
+            FetchMarketDataRequest(
+                ticker=ticker,
+                start_date=start_d.isoformat(),
+                end_date=end_d.isoformat(),
+                interval="1d",
+                include_summary=False,
+            )
+        )
+        series_list.append(result.history)
+        print(f"  {ticker}: {len(result.history.df)} rows")
+
+    # Build feature dataset
+    feature_store = PandasFeatureStore()
+    feature_dataset = feature_store.build_feature_dataset(series_list)
+    print(f"\nFeature dataset: {len(feature_dataset)} rows, "
+          f"{len(feature_dataset.columns)} columns")
+
+    # Walk-forward split
+    split_policy = WalkForwardSplitPolicy(
+        min_train_size=WF_MIN_TRAIN_DAYS,
+        test_size=WF_TEST_WINDOW,
+        step_size=WF_STEP_DAYS,
+    )
+    folds = split_policy.split_frame(feature_dataset)
+    print(f"Walk-forward folds: {len(folds)}")
+    for f in folds:
+        print(f"  Fold {f.fold_index}: train {f.train_start}..{f.train_end} | "
+              f"test {f.test_start}..{f.test_end}")
+
+    # Build model router
+    model_router = SklearnModelRouter(
+        adapters=[
+            NaiveBaselineModel(),
+            LinearSklearnModel(),
+            HistGradientBoostingModel(),
+            XGBoostModel(),
+        ]
+    )
+
+    wf_rows: list[dict[str, object]] = []
+    for model_id in MODEL_IDS:
+        print(f"\n  Evaluating {model_id} across {len(folds)} folds …")
+        fold_preds: list[pd.DataFrame] = []
+        for fold in folds:
+            eval_result = model_router.evaluate(
+                train_dataset=fold.train_df,
+                test_dataset=fold.test_df,
+                model_type=model_id,
+                target_column=TARGET_COLUMN,
+            )
+            fold_preds.append(eval_result.predictions)
+
+        combined = pd.concat(fold_preds, ignore_index=True)
+        combined["date"] = pd.to_datetime(combined["date"])
+        combined = combined.sort_values(["ticker", "date"]).reset_index(drop=True)
+
+        # Save walk-forward predictions for Script 03
+        combined.to_csv(WF_PRED_DIR / f"{model_id}.csv", index=False)
+
+        wf_rows.extend(_per_ticker_metrics(combined, model_id))
+
+    wf_df = pd.DataFrame(wf_rows)
+    wf_df.to_csv(OUTPUT_DIR / "per_stock_metrics_wf.csv", index=False)
+
+    print("\nWalk-Forward Per-Stock Metrics:")
+    print(wf_df.to_string(index=False))
+    print(f"\nSaved → {OUTPUT_DIR / 'per_stock_metrics_wf.csv'}")
+    print(f"Predictions → {WF_PRED_DIR}/")
+
+    # ── Comparison summary ───────────────────────────────────────────────────
+    print("\n" + "=" * 70)
+    print("QUICK COMPARISON: Mean RMSE by Model (Single Cutoff vs Walk-Forward)")
+    print("=" * 70)
+    sc_mean = sc_df.groupby("model_id")["rmse"].mean().rename("single_cutoff")
+    wf_mean = wf_df.groupby("model_id")["rmse"].mean().rename("walk_forward")
+    comp = pd.concat([sc_mean, wf_mean], axis=1).reindex(MODEL_IDS)
+    comp["delta"] = comp["walk_forward"] - comp["single_cutoff"]
+    print(comp.to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dissertation/03_prediction_plots.py
+++ b/scripts/dissertation/03_prediction_plots.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Script 3 — Prediction vs. Actual Plots (Single Cutoff + Walk-Forward)
+======================================================================
+After training has been run (Scripts 01 & 02), loads backtest predictions and
+produces:
+
+  Per-ticker figures  — 5 subplots (one per model) with predicted vs actual
+                        daily return on the test set.
+  Per-model figures   — all 5 tickers on one figure.
+
+Each plot type is generated for **both** the single-cutoff and walk-forward
+approaches so the reader can visually compare the two evaluation strategies.
+
+Outputs
+-------
+artifacts/dissertation/plots/<TICKER>_prediction_vs_actual.png
+artifacts/dissertation/plots/<TICKER>_prediction_vs_actual_wf.png
+artifacts/dissertation/plots/<MODEL_ID>_all_tickers.png
+artifacts/dissertation/plots/<MODEL_ID>_all_tickers_wf.png
+
+Run from repo root:
+    python scripts/dissertation/03_prediction_plots.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import pandas as pd
+
+from finsight.config.settings import get_settings
+from finsight.infrastructure.ml.registry import LocalFileModelRegistry
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════════
+TICKERS = ["AAPL", "JPM", "XOM", "KO", "TSLA"]
+MODEL_IDS = ["naive_zero", "naive_mean", "ridge", "hist_gbdt", "xgboost"]
+ARTIFACTS_DIR = "artifacts/runs"
+DISS_DIR = Path("artifacts/dissertation")
+PLOT_DIR = DISS_DIR / "plots"
+WF_PRED_DIR = DISS_DIR / "wf_predictions"
+
+MODEL_LABELS = get_settings().model_defaults.id_to_label()
+
+COLORS = {
+    "actual": "#333333",
+    "predicted": "#2196F3",
+}
+TICKER_COLORS = {
+    "AAPL": "#007AFF",
+    "JPM": "#1B5E20",
+    "XOM": "#E65100",
+    "KO": "#B71C1C",
+    "TSLA": "#6A1B9A",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Data loading helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+def load_single_cutoff_predictions() -> dict[str, pd.DataFrame]:
+    """Load predictions from artifacts/runs/ for each model_id."""
+    registry = LocalFileModelRegistry()
+    preds_by_model: dict[str, pd.DataFrame] = {}
+    for model_id in MODEL_IDS:
+        run_id = registry.latest_run_id(artifact_root=ARTIFACTS_DIR, model_id=model_id)
+        path = Path(ARTIFACTS_DIR) / run_id / "predictions.csv"
+        df = pd.read_csv(path, parse_dates=["date"])
+        preds_by_model[model_id] = df
+    return preds_by_model
+
+
+def load_walk_forward_predictions() -> dict[str, pd.DataFrame]:
+    """Load walk-forward predictions saved by Script 02."""
+    preds_by_model: dict[str, pd.DataFrame] = {}
+    for model_id in MODEL_IDS:
+        path = WF_PRED_DIR / f"{model_id}.csv"
+        if not path.exists():
+            print(f"  ⚠ Walk-forward predictions not found: {path}")
+            continue
+        df = pd.read_csv(path, parse_dates=["date"])
+        preds_by_model[model_id] = df
+    return preds_by_model
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Plot builders
+# ═══════════════════════════════════════════════════════════════════════════════
+def plot_per_ticker(
+    preds_by_model: dict[str, pd.DataFrame],
+    suffix: str = "",
+    title_extra: str = "",
+) -> None:
+    """
+    For each ticker, create a figure with 5 subplots (one per model).
+    Each subplot: predicted return vs actual return over the test dates.
+    """
+    for ticker in TICKERS:
+        fig, axes = plt.subplots(3, 2, figsize=(16, 12), sharex=True)
+        axes_flat = axes.flatten()
+        fig.suptitle(
+            f"{ticker} — Predicted vs Actual Daily Return{title_extra}",
+            fontsize=15,
+            fontweight="bold",
+            y=0.98,
+        )
+
+        for idx, model_id in enumerate(MODEL_IDS):
+            ax = axes_flat[idx]
+            df = preds_by_model.get(model_id)
+            if df is None:
+                ax.set_title(f"{MODEL_LABELS.get(model_id, model_id)} (no data)")
+                continue
+            tdf = df[df["ticker"] == ticker].sort_values("date")
+            if tdf.empty:
+                ax.set_title(f"{MODEL_LABELS.get(model_id, model_id)} (no data)")
+                continue
+
+            ax.plot(tdf["date"], tdf["y_true"], color=COLORS["actual"],
+                    linewidth=0.8, alpha=0.7, label="Actual")
+            ax.plot(tdf["date"], tdf["y_pred"], color=COLORS["predicted"],
+                    linewidth=0.8, alpha=0.7, label="Predicted")
+            ax.axhline(0, color="gray", linewidth=0.4, linestyle="--")
+            ax.set_title(f"{MODEL_LABELS.get(model_id, model_id)} — {ticker}",
+                         fontsize=11)
+            ax.set_ylabel("Daily Return", fontsize=9)
+            ax.legend(fontsize=8, loc="upper right")
+            ax.tick_params(labelsize=8)
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m"))
+            ax.xaxis.set_major_locator(mdates.MonthLocator(interval=2))
+
+        # Hide unused subplot (6th cell in 3x2 grid)
+        axes_flat[5].set_visible(False)
+
+        fig.autofmt_xdate(rotation=30)
+        plt.tight_layout(rect=[0, 0, 1, 0.96])
+        out = PLOT_DIR / f"{ticker}_prediction_vs_actual{suffix}.png"
+        fig.savefig(out, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved {out}")
+
+
+def plot_per_model(
+    preds_by_model: dict[str, pd.DataFrame],
+    suffix: str = "",
+    title_extra: str = "",
+) -> None:
+    """
+    For each model, create a figure with 5 subplots (one per ticker).
+    """
+    for model_id in MODEL_IDS:
+        df = preds_by_model.get(model_id)
+        if df is None:
+            continue
+
+        label = MODEL_LABELS.get(model_id, model_id)
+        fig, axes = plt.subplots(5, 1, figsize=(14, 16), sharex=True)
+        fig.suptitle(
+            f"{label} — All Tickers{title_extra}",
+            fontsize=15,
+            fontweight="bold",
+            y=0.99,
+        )
+
+        for idx, ticker in enumerate(TICKERS):
+            ax = axes[idx]
+            tdf = df[df["ticker"] == ticker].sort_values("date")
+            if tdf.empty:
+                ax.set_title(f"{ticker} (no data)")
+                continue
+
+            tc = TICKER_COLORS.get(ticker, "#333")
+            ax.plot(tdf["date"], tdf["y_true"], color=COLORS["actual"],
+                    linewidth=0.8, alpha=0.6, label="Actual")
+            ax.plot(tdf["date"], tdf["y_pred"], color=tc,
+                    linewidth=0.8, alpha=0.7, label=f"Predicted ({ticker})")
+            ax.axhline(0, color="gray", linewidth=0.4, linestyle="--")
+            ax.set_title(f"{label} — {ticker}", fontsize=11)
+            ax.set_ylabel("Daily Return", fontsize=9)
+            ax.legend(fontsize=8, loc="upper right")
+            ax.tick_params(labelsize=8)
+            ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m"))
+            ax.xaxis.set_major_locator(mdates.MonthLocator(interval=2))
+
+        fig.autofmt_xdate(rotation=30)
+        plt.tight_layout(rect=[0, 0, 1, 0.97])
+        out = PLOT_DIR / f"{model_id}_all_tickers{suffix}.png"
+        fig.savefig(out, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved {out}")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+def main() -> None:
+    PLOT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # ── Single Cutoff ────────────────────────────────────────────────────────
+    print("=" * 60)
+    print("Loading single-cutoff predictions …")
+    print("=" * 60)
+    sc_preds = load_single_cutoff_predictions()
+
+    print("\nPer-ticker plots (single cutoff):")
+    plot_per_ticker(sc_preds, suffix="", title_extra=" [Single Cutoff]")
+
+    print("\nPer-model plots (single cutoff):")
+    plot_per_model(sc_preds, suffix="", title_extra=" [Single Cutoff]")
+
+    # ── Walk-Forward ─────────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("Loading walk-forward predictions …")
+    print("=" * 60)
+    wf_preds = load_walk_forward_predictions()
+
+    if wf_preds:
+        print("\nPer-ticker plots (walk-forward):")
+        plot_per_ticker(wf_preds, suffix="_wf", title_extra=" [Walk-Forward]")
+
+        print("\nPer-model plots (walk-forward):")
+        plot_per_model(wf_preds, suffix="_wf", title_extra=" [Walk-Forward]")
+    else:
+        print("  ⚠ No walk-forward predictions found. Run Script 02 first.")
+
+    print(f"\nAll plots saved to {PLOT_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dissertation/04_aggregate_leaderboard.py
+++ b/scripts/dissertation/04_aggregate_leaderboard.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Script 4 — Aggregate Leaderboard (Single Cutoff + Walk-Forward)
+================================================================
+Reads the per-stock metrics CSVs produced by Script 02 and:
+
+ 1. Computes aggregate statistics per model (mean MAE, RMSE, Direction Accuracy).
+ 2. Ranks by mean RMSE (ascending).
+ 3. Groups tickers by sector and prints mean RMSE per model per sector.
+ 4. Compares single-cutoff vs walk-forward aggregate results side-by-side.
+
+Outputs
+-------
+artifacts/dissertation/aggregate_leaderboard.csv
+artifacts/dissertation/aggregate_leaderboard_wf.csv
+artifacts/dissertation/aggregate_comparison.csv
+
+Run from repo root:
+    python scripts/dissertation/04_aggregate_leaderboard.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import pandas as pd
+
+from finsight.config.settings import get_settings
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════════
+DISS_DIR = Path("artifacts/dissertation")
+MODEL_LABELS = get_settings().model_defaults.id_to_label()
+
+# Sector groupings
+SECTOR_MAP = {
+    "KO": "Consumer Staples",
+    "JPM": "Financial",
+    "XOM": "Energy",
+    "AAPL": "Technology",
+    "TSLA": "Growth / Volatile",
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+def build_aggregate(df: pd.DataFrame) -> pd.DataFrame:
+    """Mean MAE, RMSE, Direction Accuracy per model, ranked by RMSE asc."""
+    agg = (
+        df.groupby("model_id")
+        .agg(
+            mean_mae=("mae", "mean"),
+            mean_rmse=("rmse", "mean"),
+            mean_direction_accuracy=("direction_accuracy", "mean"),
+        )
+        .sort_values("mean_rmse")
+        .reset_index()
+    )
+    agg.insert(0, "rank", range(1, len(agg) + 1))
+    agg.insert(2, "model_label", agg["model_id"].map(MODEL_LABELS))
+    return agg
+
+
+def build_sector_table(df: pd.DataFrame) -> pd.DataFrame:
+    """Mean RMSE per model per sector group."""
+    df = df.copy()
+    df["sector"] = df["ticker"].map(SECTOR_MAP)
+    return (
+        df.groupby(["sector", "model_id"])["rmse"]
+        .mean()
+        .unstack("model_id")
+        .reindex(columns=df["model_id"].unique())
+    )
+
+
+def print_section(title: str) -> None:
+    print("\n" + "=" * 70)
+    print(f"  {title}")
+    print("=" * 70)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+def main() -> None:
+    sc_path = DISS_DIR / "per_stock_metrics.csv"
+    wf_path = DISS_DIR / "per_stock_metrics_wf.csv"
+
+    has_sc = sc_path.exists()
+    has_wf = wf_path.exists()
+
+    if not has_sc and not has_wf:
+        print("ERROR: No per-stock metrics CSVs found. Run Script 02 first.")
+        sys.exit(1)
+
+    # ── Single Cutoff ────────────────────────────────────────────────────────
+    sc_agg = None
+    if has_sc:
+        sc_df = pd.read_csv(sc_path)
+        sc_agg = build_aggregate(sc_df)
+        sc_agg.to_csv(DISS_DIR / "aggregate_leaderboard.csv", index=False)
+
+        print_section("Single-Cutoff Aggregate Leaderboard (ranked by Mean RMSE)")
+        print(sc_agg.to_string(index=False))
+        print(f"\nSaved → {DISS_DIR / 'aggregate_leaderboard.csv'}")
+
+        print_section("Single-Cutoff Sector Breakdown (Mean RMSE)")
+        sector_sc = build_sector_table(sc_df)
+        print(sector_sc.to_string())
+
+    # ── Walk-Forward ─────────────────────────────────────────────────────────
+    wf_agg = None
+    if has_wf:
+        wf_df = pd.read_csv(wf_path)
+        wf_agg = build_aggregate(wf_df)
+        wf_agg.to_csv(DISS_DIR / "aggregate_leaderboard_wf.csv", index=False)
+
+        print_section("Walk-Forward Aggregate Leaderboard (ranked by Mean RMSE)")
+        print(wf_agg.to_string(index=False))
+        print(f"\nSaved → {DISS_DIR / 'aggregate_leaderboard_wf.csv'}")
+
+        print_section("Walk-Forward Sector Breakdown (Mean RMSE)")
+        sector_wf = build_sector_table(wf_df)
+        print(sector_wf.to_string())
+
+    # ── Side-by-side comparison ──────────────────────────────────────────────
+    if sc_agg is not None and wf_agg is not None:
+        print_section("Comparison: Single Cutoff vs Walk-Forward")
+
+        comp = sc_agg[["model_id", "model_label", "mean_rmse", "mean_mae", "mean_direction_accuracy"]].copy()
+        comp.columns = ["model_id", "model", "sc_rmse", "sc_mae", "sc_dir_acc"]
+        wf_cols = wf_agg[["model_id", "mean_rmse", "mean_mae", "mean_direction_accuracy"]].copy()
+        wf_cols.columns = ["model_id", "wf_rmse", "wf_mae", "wf_dir_acc"]
+        comp = comp.merge(wf_cols, on="model_id", how="outer")
+        comp["rmse_delta"] = comp["wf_rmse"] - comp["sc_rmse"]
+        comp["dir_acc_delta"] = comp["wf_dir_acc"] - comp["sc_dir_acc"]
+        comp = comp.sort_values("sc_rmse")
+        comp.to_csv(DISS_DIR / "aggregate_comparison.csv", index=False)
+
+        print(comp.to_string(index=False))
+        print(f"\nSaved → {DISS_DIR / 'aggregate_comparison.csv'}")
+
+        # Rank stability check
+        sc_rank = list(sc_agg["model_id"])
+        wf_rank = list(wf_agg["model_id"])
+        if sc_rank == wf_rank:
+            print("\n✓ Model ranking is STABLE across both evaluation strategies.")
+        else:
+            print("\n⚠ Model ranking DIFFERS between strategies:")
+            print(f"  Single cutoff : {sc_rank}")
+            print(f"  Walk-forward  : {wf_rank}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dissertation/05_complexity_vs_accuracy.py
+++ b/scripts/dissertation/05_complexity_vs_accuracy.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Script 5 — Model Complexity vs. Accuracy (Single Cutoff + Walk-Forward)
+========================================================================
+Reads per-stock metrics CSVs from Script 02 and:
+
+ 1. Assigns an ordinal complexity score to each model.
+ 2. Produces scatter plots of complexity (x) vs RMSE (y) per ticker,
+    for **both** evaluation strategies (side-by-side).
+ 3. Computes Spearman rank correlation between complexity and RMSE to
+    quantify the "model complexity vs. predictive gain" relationship.
+
+Outputs
+-------
+artifacts/dissertation/plots/complexity_vs_rmse.png           — single cutoff
+artifacts/dissertation/plots/complexity_vs_rmse_wf.png        — walk-forward
+artifacts/dissertation/plots/complexity_vs_rmse_comparison.png — side-by-side
+
+Run from repo root:
+    python scripts/dissertation/05_complexity_vs_accuracy.py
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+from scipy import stats
+
+from finsight.config.settings import get_settings
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════════
+DISS_DIR = Path("artifacts/dissertation")
+PLOT_DIR = DISS_DIR / "plots"
+MODEL_LABELS = get_settings().model_defaults.id_to_label()
+
+COMPLEXITY = {
+    "naive_zero": 1,
+    "naive_mean": 2,
+    "ridge": 3,
+    "hist_gbdt": 4,
+    "xgboost": 5,
+}
+
+TICKER_MARKERS = {
+    "AAPL": ("o", "#007AFF"),
+    "JPM": ("s", "#1B5E20"),
+    "XOM": ("D", "#E65100"),
+    "KO": ("^", "#B71C1C"),
+    "TSLA": ("v", "#6A1B9A"),
+}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+def _prepare(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df["complexity"] = df["model_id"].map(COMPLEXITY)
+    df["model_label"] = df["model_id"].map(MODEL_LABELS)
+    return df
+
+
+def _scatter(
+    ax: plt.Axes,
+    df: pd.DataFrame,
+    title: str,
+) -> None:
+    """Draw one scatter panel: complexity (x) vs RMSE (y), grouped by ticker."""
+    for ticker, (marker, color) in TICKER_MARKERS.items():
+        tdf = df[df["ticker"] == ticker]
+        ax.scatter(
+            tdf["complexity"],
+            tdf["rmse"],
+            marker=marker,
+            color=color,
+            s=80,
+            label=ticker,
+            edgecolors="white",
+            linewidths=0.5,
+            zorder=3,
+        )
+        # Annotate model labels
+        for _, row in tdf.iterrows():
+            ax.annotate(
+                row["model_label"],
+                (row["complexity"], row["rmse"]),
+                textcoords="offset points",
+                xytext=(6, 4),
+                fontsize=7,
+                color=color,
+                alpha=0.8,
+            )
+
+    ax.set_xlabel("Model Complexity Score", fontsize=11)
+    ax.set_ylabel("RMSE", fontsize=11)
+    ax.set_title(title, fontsize=12, fontweight="bold")
+    ax.set_xticks(list(COMPLEXITY.values()))
+    ax.set_xticklabels(
+        [MODEL_LABELS.get(m, m) for m in COMPLEXITY],
+        fontsize=8,
+        rotation=25,
+        ha="right",
+    )
+    ax.legend(fontsize=9, loc="best", framealpha=0.9)
+    ax.grid(True, alpha=0.3)
+
+
+def _single_plot(df: pd.DataFrame, out_path: Path, title: str) -> None:
+    """Standalone scatter plot for one evaluation approach."""
+    fig, ax = plt.subplots(figsize=(10, 7))
+    _scatter(ax, df, title)
+    plt.tight_layout()
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  Saved {out_path}")
+
+
+def _spearman(df: pd.DataFrame, label: str) -> None:
+    """Print Spearman ρ between complexity and RMSE (across all tickers)."""
+    rho, p = stats.spearmanr(df["complexity"], df["rmse"])
+    print(f"\n  Spearman ρ ({label}): {rho:+.4f}  (p = {p:.4f})")
+
+    # Also per-ticker
+    for ticker in sorted(df["ticker"].unique()):
+        tdf = df[df["ticker"] == ticker]
+        if len(tdf) < 3:
+            continue
+        rho_t, p_t = stats.spearmanr(tdf["complexity"], tdf["rmse"])
+        print(f"    {ticker}: ρ = {rho_t:+.4f}  (p = {p_t:.4f})")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════════════════════════════════════
+def main() -> None:
+    PLOT_DIR.mkdir(parents=True, exist_ok=True)
+
+    sc_path = DISS_DIR / "per_stock_metrics.csv"
+    wf_path = DISS_DIR / "per_stock_metrics_wf.csv"
+    has_sc = sc_path.exists()
+    has_wf = wf_path.exists()
+
+    if not has_sc and not has_wf:
+        print("ERROR: No per-stock metrics CSVs found. Run Script 02 first.")
+        sys.exit(1)
+
+    sc_df = _prepare(pd.read_csv(sc_path)) if has_sc else None
+    wf_df = _prepare(pd.read_csv(wf_path)) if has_wf else None
+
+    # ── Individual plots ─────────────────────────────────────────────────────
+    if sc_df is not None:
+        print("Single-cutoff scatter plot:")
+        _single_plot(
+            sc_df,
+            PLOT_DIR / "complexity_vs_rmse.png",
+            "Model Complexity vs. RMSE [Single Cutoff]",
+        )
+        _spearman(sc_df, "Single Cutoff — all tickers pooled")
+
+    if wf_df is not None:
+        print("\nWalk-forward scatter plot:")
+        _single_plot(
+            wf_df,
+            PLOT_DIR / "complexity_vs_rmse_wf.png",
+            "Model Complexity vs. RMSE [Walk-Forward]",
+        )
+        _spearman(wf_df, "Walk-Forward — all tickers pooled")
+
+    # ── Side-by-side comparison ──────────────────────────────────────────────
+    if sc_df is not None and wf_df is not None:
+        print("\nSide-by-side comparison plot:")
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(18, 7), sharey=True)
+        _scatter(ax1, sc_df, "Single Cutoff")
+        _scatter(ax2, wf_df, "Walk-Forward")
+        fig.suptitle(
+            "Model Complexity vs. RMSE — Evaluation Strategy Comparison",
+            fontsize=14,
+            fontweight="bold",
+            y=1.01,
+        )
+        plt.tight_layout()
+        out = PLOT_DIR / "complexity_vs_rmse_comparison.png"
+        fig.savefig(out, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved {out}")
+
+    print(f"\nAll plots saved to {PLOT_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dissertation/README.md
+++ b/scripts/dissertation/README.md
@@ -1,0 +1,89 @@
+# Dissertation — Chapter 5 Experimental Scripts
+
+Scripts for reproducing the experimental results in *Chapter 5: Theoretical and
+Experimental Results* of the FinSight-AI dissertation on AI-Driven Financial
+Market Trend Prediction.
+
+## Evaluation strategies
+
+Every script produces results for **two** evaluation strategies so they can be
+compared directly:
+
+| Strategy | Description |
+|---|---|
+| **Single Cutoff** | Fixed train/test split at `2024-01-01`. Train on 2021–2023, test on 2024. |
+| **Walk-Forward** | Expanding-window validation with `min_train = 504 days` (~2 yr), `test_window = 21 days` (~1 mo), `step = 21 days`. Test period naturally covers ≈ 2024, making it directly comparable with the single cutoff. |
+
+## Experimental conditions (fixed)
+
+| Parameter | Value |
+|---|---|
+| Training window | `--years 3` |
+| Cutoff date | `2024-01-01` |
+| End date | `2024-12-31` |
+| Models | `naive_zero`, `naive_mean`, `ridge`, `hist_gbdt`, `xgboost` |
+| Tickers | AAPL, JPM, XOM, KO, TSLA |
+| Metrics | MAE, RMSE, Direction Accuracy |
+
+## Prerequisites
+
+```bash
+# From the repository root
+pip install -e .          # or: pip install -r requirements.txt
+pip install scipy         # needed by Script 05 (Spearman correlation)
+```
+
+## Execution order
+
+Run all scripts **from the repository root directory**.
+
+```bash
+# Step 1 — Train all models (single cutoff) and print leaderboard
+bash scripts/dissertation/01_run_all_training.sh
+
+# Step 2 — Compute per-stock metrics (single cutoff + walk-forward)
+python scripts/dissertation/02_per_stock_metrics.py
+
+# Step 3 — Generate prediction-vs-actual plots (both strategies)
+python scripts/dissertation/03_prediction_plots.py
+
+# Step 4 — Aggregate leaderboard tables + comparison (both strategies)
+python scripts/dissertation/04_aggregate_leaderboard.py
+
+# Step 5 — Complexity-vs-accuracy scatter plots + Spearman ρ (both strategies)
+python scripts/dissertation/05_complexity_vs_accuracy.py
+```
+
+> **Note:** Script 01 runs the CLI-based training and saves artifacts to
+> `artifacts/runs/`. Script 02 re-trains via the Python API (same conditions)
+> and additionally runs walk-forward validation. Scripts 03–05 only read
+> artifacts and CSV files produced by the earlier scripts.
+
+## Output artifacts
+
+```
+artifacts/
+├── runs/                                   # Model run artifacts (Script 01 & 02)
+│   └── <timestamp>__<model_id>/
+│       ├── model.joblib
+│       ├── metrics.json
+│       ├── manifest.json
+│       └── predictions.csv
+└── dissertation/
+    ├── leaderboard.txt                     # CLI compare output (Script 01)
+    ├── per_stock_metrics.csv               # Per-ticker metrics — single cutoff (Script 02)
+    ├── per_stock_metrics_wf.csv            # Per-ticker metrics — walk-forward (Script 02)
+    ├── aggregate_leaderboard.csv           # Aggregate leaderboard — single cutoff (Script 04)
+    ├── aggregate_leaderboard_wf.csv        # Aggregate leaderboard — walk-forward (Script 04)
+    ├── aggregate_comparison.csv            # Side-by-side comparison table (Script 04)
+    ├── wf_predictions/                     # Walk-forward test predictions (Script 02)
+    │   └── <model_id>.csv
+    └── plots/                              # All figures (Scripts 03 & 05)
+        ├── <TICKER>_prediction_vs_actual.png
+        ├── <TICKER>_prediction_vs_actual_wf.png
+        ├── <MODEL_ID>_all_tickers.png
+        ├── <MODEL_ID>_all_tickers_wf.png
+        ├── complexity_vs_rmse.png
+        ├── complexity_vs_rmse_wf.png
+        └── complexity_vs_rmse_comparison.png
+```


### PR DESCRIPTION
## What

Adds 5 experiment scripts + README under `scripts/dissertation/` for reproducing all Chapter 5 experimental results.

## Two evaluation strategies

Each script produces results for **both** approaches so they can be directly compared:

1. **Single Cutoff** — fixed train/test split at 2024-01-01 (train on 2021–2023, test on 2024)
2. **Walk-Forward** — expanding-window validation (min_train=504 days ≈ 2 yr, test_window=21 days, step=21 days). Test period naturally aligns with 2024.

## Scripts

| # | File | Purpose |
|---|------|---------|
| 1 | `01_run_all_training.sh` | CLI-based single-cutoff training + leaderboard |
| 2 | `02_per_stock_metrics.py` | Per-ticker metrics for both strategies (MAE, RMSE, Dir. Acc.) |
| 3 | `03_prediction_plots.py` | Predicted vs actual return plots for both strategies |
| 4 | `04_aggregate_leaderboard.py` | Aggregate leaderboards + side-by-side comparison + sector breakdown |
| 5 | `05_complexity_vs_accuracy.py` | Complexity vs RMSE scatter plots + Spearman rank correlation |

## Key design decisions

- Walk-forward uses `min_train_days=504` so the test period covers ≈ 2024, directly comparable with the single-cutoff test period
- No existing source code modified — all scripts only import and use existing pipelines
- Walk-forward predictions saved to `artifacts/dissertation/wf_predictions/` for reuse by Scripts 03–05
- `scipy` added as a dependency (Script 05 uses `spearmanr`)

## Output artifacts

See `scripts/dissertation/README.md` for the full artifact tree.
